### PR TITLE
[Fix]: Fix bug on last Obsidian version, support for moving files and option to disable collapse

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,22 +1,25 @@
 {
-    "root": true,
-    "parser": "@typescript-eslint/parser",
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:@typescript-eslint/recommended"
-    ], 
-    "parserOptions": {
-        "sourceType": "module"
-    },
-    "rules": {
-      "no-unused-vars": "off",
-      "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }],
-      "@typescript-eslint/ban-ts-comment": "off",
-      "no-prototype-builtins": "off",
-      "@typescript-eslint/no-empty-function": "off"
-    } 
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "rules": {
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }],
+    "@typescript-eslint/ban-ts-comment": "off",
+    "no-prototype-builtins": "off",
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/ban-tslint-comment": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-empty-interface": "off",
+    "@typescript-eslint/no-this-alias": "off",
+    "@typescript-eslint/no-non-null-assertion": "off"
   }
+}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,6 +26,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm ci
+    - run: npm install
     - run: npm run build --if-present
     - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,6 +26,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm install
+    - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,31 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x, 20.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,7 +31,7 @@ jobs:
     - run: npm test
 
     - name: Create Release and Upload Release Asset
-      uses: bartender/action-nodejs-release@v1
+      uses: zansbang/obsidian-bartender/action-nodejs-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
         tag_name: ${{ github.ref }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x]
+        node-version: [20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -29,3 +29,13 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test
+
+    - name: Create Release and Upload Release Asset
+      uses: bartender/action-nodejs-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        tag_name: ${{ github.ref }}
+        name: Release ${{ github.ref }}
+        body: TODO New Release.
+        draft: false
+        prerelease: false

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,7 +31,7 @@ jobs:
     - run: npm test
 
     - name: Create Release and Upload Release Asset
-      uses: zansbang/obsidian-bartender/action-nodejs-release
+      uses: zansbang/obsidian-bartender/action-nodejs-release@ref
       if: startsWith(github.ref, 'refs/tags/')
       with:
         tag_name: ${{ github.ref }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,7 +31,7 @@ jobs:
     - run: npm test
 
     - name: Create Release and Upload Release Asset
-      uses: zansbang/obsidian-bartender/action-nodejs-release@v1
+      uses: zansbang/obsidian-bartender/action-nodejs-release
       if: startsWith(github.ref, 'refs/tags/')
       with:
         tag_name: ${{ github.ref }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "fuse.js": "^6.5.3"
       },
       "devDependencies": {
-        "@types/node": "^16.11.6",
+        "@types/electron": "npm:@ophidian/electron-types",
+        "@types/node": "^20.14.2",
+        "@types/obsidian-typings": "npm:obsidian-typings@^1.1.6",
         "@types/sortablejs": "^1.10.7",
         "@typescript-eslint/eslint-plugin": "^5.2.0",
         "@typescript-eslint/parser": "^5.2.0",
@@ -20,7 +22,7 @@
         "esbuild": "0.13.12",
         "i18next": "^21.6.10",
         "monkey-around": "^2.2.0",
-        "obsidian": "^0.15.1",
+        "obsidian": "latest",
         "sortablejs": "^1.15.0",
         "tslib": "2.3.1",
         "typescript": "4.4.4"
@@ -190,17 +192,24 @@
       }
     },
     "node_modules/@types/codemirror": {
-      "version": "0.0.108",
-      "resolved": "https://registry.npmmirror.com/@types/codemirror/-/codemirror-0.0.108.tgz",
-      "integrity": "sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==",
+      "version": "5.60.8",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+      "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
       "dev": true,
       "dependencies": {
         "@types/tern": "*"
       }
     },
+    "node_modules/@types/electron": {
+      "name": "@ophidian/electron-types",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@ophidian/electron-types/-/electron-types-24.3.1.tgz",
+      "integrity": "sha512-fzvB7sQMxTbQHbp3rcYIxaqHiWjFnpSBVvZBSDH0Rq0xMvihBH1D4/O2JqybSlVpYtbvXR4nVKeH3w4JmHLTag==",
+      "dev": true
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
@@ -211,10 +220,25 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.83",
-      "resolved": "https://registry.npmmirror.com/@types/node/-/node-16.18.83.tgz",
-      "integrity": "sha512-TmBqzDY/GeCEmLob/31SunOQnqYE3ZiiuEh1U9o3HqE1E2cqKZQA5RQg4krEguCY3StnkXyDmCny75qyFLx/rA==",
-      "dev": true
+      "version": "20.14.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
+      "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/obsidian-typings": {
+      "name": "obsidian-typings",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/obsidian-typings/-/obsidian-typings-1.1.6.tgz",
+      "integrity": "sha512-p3iWfvHDJfrwdYKAhb8adlBVOGtGteEy5nE7Jzhb8K5nyrTb5DvOtG+BQGneVM7Ou6UMkZnRoOLPkhJMXLquGw==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/electron": "npm:@ophidian/electron-types",
+        "@types/node": "^20.10.7",
+        "obsidian": "^1.5.7-1"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
@@ -230,7 +254,7 @@
     },
     "node_modules/@types/tern": {
       "version": "0.23.9",
-      "resolved": "https://registry.npmmirror.com/@types/tern/-/tern-0.23.9.tgz",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
       "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
       "dev": true,
       "dependencies": {
@@ -1544,12 +1568,12 @@
       "dev": true
     },
     "node_modules/obsidian": {
-      "version": "0.15.9",
-      "resolved": "https://registry.npmmirror.com/obsidian/-/obsidian-0.15.9.tgz",
-      "integrity": "sha512-w3JL/IM3/U61rjFSFIFDSv+pcHn3mH1EIRN40kBkC/lGYqjFSPbr6daQe08QkskBz/GAYIeBoaKQIcgU9vV3LQ==",
+      "version": "1.5.7-1",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.5.7-1.tgz",
+      "integrity": "sha512-T5ZRuQ1FnfXqEoakTTHVDYvzUEEoT8zSPnQCW31PVgYwG4D4tZCQfKHN2hTz1ifnCe8upvwa6mBTAP2WUA5Vng==",
       "dev": true,
       "dependencies": {
-        "@types/codemirror": "0.0.108",
+        "@types/codemirror": "5.60.8",
         "moment": "2.29.4"
       },
       "peerDependencies": {
@@ -1923,6 +1947,12 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1984 @@
+{
+  "name": "obsidian-bartender",
+  "version": "0.5.9",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "obsidian-bartender",
+      "version": "0.5.9",
+      "license": "MIT",
+      "dependencies": {
+        "fuse.js": "^6.5.3"
+      },
+      "devDependencies": {
+        "@types/node": "^16.11.6",
+        "@types/sortablejs": "^1.10.7",
+        "@typescript-eslint/eslint-plugin": "^5.2.0",
+        "@typescript-eslint/parser": "^5.2.0",
+        "builtin-modules": "^3.2.0",
+        "esbuild": "0.13.12",
+        "i18next": "^21.6.10",
+        "monkey-around": "^2.2.0",
+        "obsidian": "^0.15.1",
+        "sortablejs": "^1.15.0",
+        "tslib": "2.3.1",
+        "typescript": "4.4.4"
+      }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmmirror.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmmirror.com/@codemirror/state/-/state-6.4.1.tgz",
+      "integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmmirror.com/@codemirror/view/-/view-6.24.1.tgz",
+      "integrity": "sha512-sBfP4rniPBRQzNakwuQEqjEuiJDWJyF2kqLLqij4WXRoVwPPJfjx966Eq3F7+OPQxDtMt/Q9MWLoZLWjeveBlg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.4.0",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmmirror.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmmirror.com/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmmirror.com/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmmirror.com/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.14",
+      "resolved": "https://registry.npmmirror.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12.22"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmmirror.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmmirror.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmmirror.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@types/codemirror": {
+      "version": "0.0.108",
+      "resolved": "https://registry.npmmirror.com/@types/codemirror/-/codemirror-0.0.108.tgz",
+      "integrity": "sha512-3FGFcus0P7C2UOGCNUVENqObEb4SFk+S8Dnxq7K6aIsLVs/vDtlangl3PEO0ykaKXyK56swVF6Nho7VsA44uhw==",
+      "dev": true,
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmmirror.com/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "16.18.83",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-16.18.83.tgz",
+      "integrity": "sha512-TmBqzDY/GeCEmLob/31SunOQnqYE3ZiiuEh1U9o3HqE1E2cqKZQA5RQg4krEguCY3StnkXyDmCny75qyFLx/rA==",
+      "dev": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmmirror.com/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true
+    },
+    "node_modules/@types/sortablejs": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmmirror.com/@types/sortablejs/-/sortablejs-1.15.8.tgz",
+      "integrity": "sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg==",
+      "dev": true
+    },
+    "node_modules/@types/tern": {
+      "version": "0.23.9",
+      "resolved": "https://registry.npmmirror.com/@types/tern/-/tern-0.23.9.tgz",
+      "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmmirror.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+      "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/type-utils": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmmirror.com/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmmirror.com/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmmirror.com/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+      "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "@typescript-eslint/utils": "5.62.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmmirror.com/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmmirror.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmmirror.com/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmmirror.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/acorn": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmmirror.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peer": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmmirror.com/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmmirror.com/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmmirror.com/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmmirror.com/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild/-/esbuild-0.13.12.tgz",
+      "integrity": "sha512-vTKKUt+yoz61U/BbrnmlG9XIjwpdIxmHB8DlPR0AAW6OdS+nBQBci6LUHU2q9WbBobMEIQxxDpKbkmOGYvxsow==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "optionalDependencies": {
+        "esbuild-android-arm64": "0.13.12",
+        "esbuild-darwin-64": "0.13.12",
+        "esbuild-darwin-arm64": "0.13.12",
+        "esbuild-freebsd-64": "0.13.12",
+        "esbuild-freebsd-arm64": "0.13.12",
+        "esbuild-linux-32": "0.13.12",
+        "esbuild-linux-64": "0.13.12",
+        "esbuild-linux-arm": "0.13.12",
+        "esbuild-linux-arm64": "0.13.12",
+        "esbuild-linux-mips64le": "0.13.12",
+        "esbuild-linux-ppc64le": "0.13.12",
+        "esbuild-netbsd-64": "0.13.12",
+        "esbuild-openbsd-64": "0.13.12",
+        "esbuild-sunos-64": "0.13.12",
+        "esbuild-windows-32": "0.13.12",
+        "esbuild-windows-64": "0.13.12",
+        "esbuild-windows-arm64": "0.13.12"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-android-arm64/-/esbuild-android-arm64-0.13.12.tgz",
+      "integrity": "sha512-TSVZVrb4EIXz6KaYjXfTzPyyRpXV5zgYIADXtQsIenjZ78myvDGaPi11o4ZSaHIwFHsuwkB6ne5SZRBwAQ7maw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-darwin-64/-/esbuild-darwin-64-0.13.12.tgz",
+      "integrity": "sha512-c51C+N+UHySoV2lgfWSwwmlnLnL0JWj/LzuZt9Ltk9ub1s2Y8cr6SQV5W3mqVH1egUceew6KZ8GyI4nwu+fhsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.12.tgz",
+      "integrity": "sha512-JvAMtshP45Hd8A8wOzjkY1xAnTKTYuP/QUaKp5eUQGX+76GIie3fCdUUr2ZEKdvpSImNqxiZSIMziEiGB5oUmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.12.tgz",
+      "integrity": "sha512-r6On/Skv9f0ZjTu6PW5o7pdXr8aOgtFOEURJZYf1XAJs0IQ+gW+o1DzXjVkIoT+n1cm3N/t1KRJfX71MPg/ZUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.12.tgz",
+      "integrity": "sha512-F6LmI2Q1gii073kmBE3NOTt/6zLL5zvZsxNLF8PMAwdHc+iBhD1vzfI8uQZMJA1IgXa3ocr3L3DJH9fLGXy6Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-linux-32/-/esbuild-linux-32-0.13.12.tgz",
+      "integrity": "sha512-U1UZwG3UIwF7/V4tCVAo/nkBV9ag5KJiJTt+gaCmLVWH3bPLX7y+fNlhIWZy8raTMnXhMKfaTvWZ9TtmXzvkuQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-linux-64/-/esbuild-linux-64-0.13.12.tgz",
+      "integrity": "sha512-YpXSwtu2NxN3N4ifJxEdsgd6Q5d8LYqskrAwjmoCT6yQnEHJSF5uWcxv783HWN7lnGpJi9KUtDvYsnMdyGw71Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-linux-arm/-/esbuild-linux-arm-0.13.12.tgz",
+      "integrity": "sha512-SyiT/JKxU6J+DY2qUiSLZJqCAftIt3uoGejZ0HDnUM2MGJqEGSGh7p1ecVL2gna3PxS4P+j6WAehCwgkBPXNIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.12.tgz",
+      "integrity": "sha512-sgDNb8kb3BVodtAlcFGgwk+43KFCYjnFOaOfJibXnnIojNWuJHpL6aQJ4mumzNWw8Rt1xEtDQyuGK9f+Y24jGA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.12.tgz",
+      "integrity": "sha512-qQJHlZBG+QwVIA8AbTEtbvF084QgDi4DaUsUnA+EolY1bxrG+UyOuGflM2ZritGhfS/k7THFjJbjH2wIeoKA2g==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.12.tgz",
+      "integrity": "sha512-2dSnm1ldL7Lppwlo04CGQUpwNn5hGqXI38OzaoPOkRsBRWFBozyGxTFSee/zHFS+Pdh3b28JJbRK3owrrRgWNw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.12.tgz",
+      "integrity": "sha512-D4raxr02dcRiQNbxOLzpqBzcJNFAdsDNxjUbKkDMZBkL54Z0vZh4LRndycdZAMcIdizC/l/Yp/ZsBdAFxc5nbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ]
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.12.tgz",
+      "integrity": "sha512-KuLCmYMb2kh05QuPJ+va60bKIH5wHL8ypDkmpy47lzwmdxNsuySeCMHuTv5o2Af1RUn5KLO5ZxaZeq4GEY7DaQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-sunos-64/-/esbuild-sunos-64-0.13.12.tgz",
+      "integrity": "sha512-jBsF+e0woK3miKI8ufGWKG3o3rY9DpHvCVRn5eburMIIE+2c+y3IZ1srsthKyKI6kkXLvV4Cf/E7w56kLipMXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ]
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-windows-32/-/esbuild-windows-32-0.13.12.tgz",
+      "integrity": "sha512-L9m4lLFQrFeR7F+eLZXG82SbXZfUhyfu6CexZEil6vm+lc7GDCE0Q8DiNutkpzjv1+RAbIGVva9muItQ7HVTkQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-windows-64/-/esbuild-windows-64-0.13.12.tgz",
+      "integrity": "sha512-k4tX4uJlSbSkfs78W5d9+I9gpd+7N95W7H2bgOMFPsYREVJs31+Q2gLLHlsnlY95zBoPQMIzHooUIsixQIBjaQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmmirror.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.12.tgz",
+      "integrity": "sha512-2tTv/BpYRIvuwHpp2M960nG7uvL+d78LFW/ikPItO+2GfK51CswIKSetSpDii+cjz8e9iSPgs+BU4o8nWICBwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmmirror.com/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmmirror.com/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmmirror.com/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmmirror.com/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmmirror.com/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esquery/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmmirror.com/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmmirror.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/fastq": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmmirror.com/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmmirror.com/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmmirror.com/flatted/-/flatted-3.3.1.tgz",
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmmirror.com/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmmirror.com/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmmirror.com/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmmirror.com/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmmirror.com/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "21.10.0",
+      "resolved": "https://registry.npmmirror.com/i18next/-/i18next-21.10.0.tgz",
+      "integrity": "sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.17.2"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmmirror.com/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmmirror.com/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmmirror.com/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmmirror.com/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmmirror.com/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmmirror.com/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmmirror.com/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmmirror.com/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmmirror.com/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmmirror.com/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/monkey-around": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/monkey-around/-/monkey-around-2.3.0.tgz",
+      "integrity": "sha512-QWcCUWjqE/MCk9cXlSKZ1Qc486LD439xw/Ak8Nt6l2PuL9+yrc9TJakt7OHDuOqPRYY4nTWBAEFKn32PE/SfXA==",
+      "dev": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true
+    },
+    "node_modules/obsidian": {
+      "version": "0.15.9",
+      "resolved": "https://registry.npmmirror.com/obsidian/-/obsidian-0.15.9.tgz",
+      "integrity": "sha512-w3JL/IM3/U61rjFSFIFDSv+pcHn3mH1EIRN40kBkC/lGYqjFSPbr6daQe08QkskBz/GAYIeBoaKQIcgU9vV3LQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/codemirror": "0.0.108",
+        "moment": "2.29.4"
+      },
+      "peerDependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmmirror.com/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmmirror.com/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmmirror.com/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmmirror.com/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmmirror.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmmirror.com/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sortablejs": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmmirror.com/sortablejs/-/sortablejs-1.15.2.tgz",
+      "integrity": "sha512-FJF5jgdfvoKn1MAKSdGs33bIqLi3LmsgVTliuX6iITj834F+JRQZN90Z93yql8h0K2t0RwDPBmxwlbZfDcxNZA==",
+      "dev": true
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/style-mod/-/style-mod-4.1.0.tgz",
+      "integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmmirror.com/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmmirror.com/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmmirror.com/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmmirror.com/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmmirror.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmmirror.com/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "esbuild": "0.13.12",
     "i18next": "^21.6.10",
     "monkey-around": "^2.2.0",
-    "obsidian": "^0.15.1",
+    "obsidian": "latest",
     "sortablejs": "^1.15.0",
     "tslib": "2.3.1",
     "typescript": "4.4.4"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^16.11.6",
+    "@types/electron": "npm:@ophidian/electron-types",
+    "@types/node": "^20.14.2",
+    "@types/obsidian-typings": "npm:obsidian-typings@^1.1.6",
     "@types/sortablejs": "^1.10.7",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1425 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      fuse.js:
+        specifier: ^6.5.3
+        version: 6.6.2
+    devDependencies:
+      '@types/electron':
+        specifier: npm:@ophidian/electron-types
+        version: '@ophidian/electron-types@24.3.1'
+      '@types/node':
+        specifier: ^20.14.2
+        version: 20.14.2
+      '@types/obsidian-typings':
+        specifier: npm:obsidian-typings@^1.1.6
+        version: obsidian-typings@1.1.6(@ophidian/electron-types@24.3.1)(@types/node@20.14.2)(obsidian@1.5.7-1(@codemirror/state@6.4.1)(@codemirror/view@6.27.0))
+      '@types/sortablejs':
+        specifier: ^1.10.7
+        version: 1.15.8
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^5.2.0
+        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.4.4))(eslint@8.57.0)(typescript@4.4.4)
+      '@typescript-eslint/parser':
+        specifier: ^5.2.0
+        version: 5.62.0(eslint@8.57.0)(typescript@4.4.4)
+      builtin-modules:
+        specifier: ^3.2.0
+        version: 3.3.0
+      esbuild:
+        specifier: 0.13.12
+        version: 0.13.12
+      i18next:
+        specifier: ^21.6.10
+        version: 21.10.0
+      monkey-around:
+        specifier: ^2.2.0
+        version: 2.3.0
+      obsidian:
+        specifier: latest
+        version: 1.5.7-1(@codemirror/state@6.4.1)(@codemirror/view@6.27.0)
+      sortablejs:
+        specifier: ^1.15.0
+        version: 1.15.2
+      tslib:
+        specifier: 2.3.1
+        version: 2.3.1
+      typescript:
+        specifier: 4.4.4
+        version: 4.4.4
+
+packages:
+
+  '@babel/runtime@7.24.7':
+    resolution: {integrity: sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==}
+    engines: {node: '>=6.9.0'}
+
+  '@codemirror/state@6.4.1':
+    resolution: {integrity: sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==}
+
+  '@codemirror/view@6.27.0':
+    resolution: {integrity: sha512-8kqX1sHbVW1lVzWwrjAbh4dR7eKhV8eIQ952JKaBXOoXE04WncoqCy4DMU701LSrPZ3N2Q4zsTawz7GQ+2mrUw==}
+
+  '@eslint-community/eslint-utils@4.4.0':
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.10.1':
+    resolution: {integrity: sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/eslintrc@2.1.4':
+    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@eslint/js@8.57.0':
+    resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@humanwhocodes/config-array@0.11.14':
+    resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
+    engines: {node: '>=10.10.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/object-schema@2.0.3':
+    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@ophidian/electron-types@24.3.1':
+    resolution: {integrity: sha512-fzvB7sQMxTbQHbp3rcYIxaqHiWjFnpSBVvZBSDH0Rq0xMvihBH1D4/O2JqybSlVpYtbvXR4nVKeH3w4JmHLTag==}
+
+  '@types/codemirror@5.60.8':
+    resolution: {integrity: sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==}
+
+  '@types/estree@1.0.5':
+    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@20.14.2':
+    resolution: {integrity: sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==}
+
+  '@types/semver@7.5.8':
+    resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
+
+  '@types/sortablejs@1.15.8':
+    resolution: {integrity: sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg==}
+
+  '@types/tern@0.23.9':
+    resolution: {integrity: sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==}
+
+  '@typescript-eslint/eslint-plugin@5.62.0':
+    resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/parser@5.62.0':
+    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/scope-manager@5.62.0':
+    resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@typescript-eslint/type-utils@5.62.0':
+    resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/types@5.62.0':
+    resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@typescript-eslint/typescript-estree@5.62.0':
+    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/utils@5.62.0':
+    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@typescript-eslint/visitor-keys@5.62.0':
+    resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@ungap/structured-clone@1.2.0':
+    resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  builtin-modules@3.3.0:
+    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
+    engines: {node: '>=6'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@7.0.3:
+    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+    engines: {node: '>= 8'}
+
+  debug@4.3.5:
+    resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
+
+  esbuild-android-arm64@0.13.12:
+    resolution: {integrity: sha512-TSVZVrb4EIXz6KaYjXfTzPyyRpXV5zgYIADXtQsIenjZ78myvDGaPi11o4ZSaHIwFHsuwkB6ne5SZRBwAQ7maw==}
+    cpu: [arm64]
+    os: [android]
+
+  esbuild-darwin-64@0.13.12:
+    resolution: {integrity: sha512-c51C+N+UHySoV2lgfWSwwmlnLnL0JWj/LzuZt9Ltk9ub1s2Y8cr6SQV5W3mqVH1egUceew6KZ8GyI4nwu+fhsw==}
+    cpu: [x64]
+    os: [darwin]
+
+  esbuild-darwin-arm64@0.13.12:
+    resolution: {integrity: sha512-JvAMtshP45Hd8A8wOzjkY1xAnTKTYuP/QUaKp5eUQGX+76GIie3fCdUUr2ZEKdvpSImNqxiZSIMziEiGB5oUmQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  esbuild-freebsd-64@0.13.12:
+    resolution: {integrity: sha512-r6On/Skv9f0ZjTu6PW5o7pdXr8aOgtFOEURJZYf1XAJs0IQ+gW+o1DzXjVkIoT+n1cm3N/t1KRJfX71MPg/ZUA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  esbuild-freebsd-arm64@0.13.12:
+    resolution: {integrity: sha512-F6LmI2Q1gii073kmBE3NOTt/6zLL5zvZsxNLF8PMAwdHc+iBhD1vzfI8uQZMJA1IgXa3ocr3L3DJH9fLGXy6Yw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  esbuild-linux-32@0.13.12:
+    resolution: {integrity: sha512-U1UZwG3UIwF7/V4tCVAo/nkBV9ag5KJiJTt+gaCmLVWH3bPLX7y+fNlhIWZy8raTMnXhMKfaTvWZ9TtmXzvkuQ==}
+    cpu: [ia32]
+    os: [linux]
+
+  esbuild-linux-64@0.13.12:
+    resolution: {integrity: sha512-YpXSwtu2NxN3N4ifJxEdsgd6Q5d8LYqskrAwjmoCT6yQnEHJSF5uWcxv783HWN7lnGpJi9KUtDvYsnMdyGw71Q==}
+    cpu: [x64]
+    os: [linux]
+
+  esbuild-linux-arm64@0.13.12:
+    resolution: {integrity: sha512-sgDNb8kb3BVodtAlcFGgwk+43KFCYjnFOaOfJibXnnIojNWuJHpL6aQJ4mumzNWw8Rt1xEtDQyuGK9f+Y24jGA==}
+    cpu: [arm64]
+    os: [linux]
+
+  esbuild-linux-arm@0.13.12:
+    resolution: {integrity: sha512-SyiT/JKxU6J+DY2qUiSLZJqCAftIt3uoGejZ0HDnUM2MGJqEGSGh7p1ecVL2gna3PxS4P+j6WAehCwgkBPXNIw==}
+    cpu: [arm]
+    os: [linux]
+
+  esbuild-linux-mips64le@0.13.12:
+    resolution: {integrity: sha512-qQJHlZBG+QwVIA8AbTEtbvF084QgDi4DaUsUnA+EolY1bxrG+UyOuGflM2ZritGhfS/k7THFjJbjH2wIeoKA2g==}
+    cpu: [mips64el]
+    os: [linux]
+
+  esbuild-linux-ppc64le@0.13.12:
+    resolution: {integrity: sha512-2dSnm1ldL7Lppwlo04CGQUpwNn5hGqXI38OzaoPOkRsBRWFBozyGxTFSee/zHFS+Pdh3b28JJbRK3owrrRgWNw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  esbuild-netbsd-64@0.13.12:
+    resolution: {integrity: sha512-D4raxr02dcRiQNbxOLzpqBzcJNFAdsDNxjUbKkDMZBkL54Z0vZh4LRndycdZAMcIdizC/l/Yp/ZsBdAFxc5nbA==}
+    cpu: [x64]
+    os: [netbsd]
+
+  esbuild-openbsd-64@0.13.12:
+    resolution: {integrity: sha512-KuLCmYMb2kh05QuPJ+va60bKIH5wHL8ypDkmpy47lzwmdxNsuySeCMHuTv5o2Af1RUn5KLO5ZxaZeq4GEY7DaQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  esbuild-sunos-64@0.13.12:
+    resolution: {integrity: sha512-jBsF+e0woK3miKI8ufGWKG3o3rY9DpHvCVRn5eburMIIE+2c+y3IZ1srsthKyKI6kkXLvV4Cf/E7w56kLipMXw==}
+    cpu: [x64]
+    os: [sunos]
+
+  esbuild-windows-32@0.13.12:
+    resolution: {integrity: sha512-L9m4lLFQrFeR7F+eLZXG82SbXZfUhyfu6CexZEil6vm+lc7GDCE0Q8DiNutkpzjv1+RAbIGVva9muItQ7HVTkQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  esbuild-windows-64@0.13.12:
+    resolution: {integrity: sha512-k4tX4uJlSbSkfs78W5d9+I9gpd+7N95W7H2bgOMFPsYREVJs31+Q2gLLHlsnlY95zBoPQMIzHooUIsixQIBjaQ==}
+    cpu: [x64]
+    os: [win32]
+
+  esbuild-windows-arm64@0.13.12:
+    resolution: {integrity: sha512-2tTv/BpYRIvuwHpp2M960nG7uvL+d78LFW/ikPItO+2GfK51CswIKSetSpDii+cjz8e9iSPgs+BU4o8nWICBwQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  esbuild@0.13.12:
+    resolution: {integrity: sha512-vTKKUt+yoz61U/BbrnmlG9XIjwpdIxmHB8DlPR0AAW6OdS+nBQBci6LUHU2q9WbBobMEIQxxDpKbkmOGYvxsow==}
+    hasBin: true
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+
+  eslint-scope@7.2.2:
+    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint@8.57.0:
+    resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    hasBin: true
+
+  espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  esquery@1.5.0:
+    resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.2:
+    resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.17.1:
+    resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
+
+  file-entry-cache@6.0.1:
+    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@3.2.0:
+    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+
+  flatted@3.3.1:
+    resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fuse.js@6.6.2:
+    resolution: {integrity: sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==}
+    engines: {node: '>=10'}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
+
+  globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
+    engines: {node: '>=8'}
+
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+
+  graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  i18next@21.10.0:
+    resolution: {integrity: sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==}
+
+  ignore@5.3.1:
+    resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.0:
+    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-path-inside@3.0.3:
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.7:
+    resolution: {integrity: sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==}
+    engines: {node: '>=8.6'}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  moment@2.29.4:
+    resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
+
+  monkey-around@2.3.0:
+    resolution: {integrity: sha512-QWcCUWjqE/MCk9cXlSKZ1Qc486LD439xw/Ak8Nt6l2PuL9+yrc9TJakt7OHDuOqPRYY4nTWBAEFKn32PE/SfXA==}
+
+  ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
+  natural-compare-lite@1.4.0:
+    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  obsidian-typings@1.1.6:
+    resolution: {integrity: sha512-p3iWfvHDJfrwdYKAhb8adlBVOGtGteEy5nE7Jzhb8K5nyrTb5DvOtG+BQGneVM7Ou6UMkZnRoOLPkhJMXLquGw==}
+    peerDependencies:
+      '@types/electron': npm:@ophidian/electron-types
+      '@types/node': ^20.10.7
+      obsidian: ^1.5.7-1
+
+  obsidian@1.5.7-1:
+    resolution: {integrity: sha512-T5ZRuQ1FnfXqEoakTTHVDYvzUEEoT8zSPnQCW31PVgYwG4D4tZCQfKHN2hTz1ifnCe8upvwa6mBTAP2WUA5Vng==}
+    peerDependencies:
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  reusify@1.0.4:
+    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  semver@7.6.2:
+    resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
+  sortablejs@1.15.2:
+    resolution: {integrity: sha512-FJF5jgdfvoKn1MAKSdGs33bIqLi3LmsgVTliuX6iITj834F+JRQZN90Z93yql8h0K2t0RwDPBmxwlbZfDcxNZA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  style-mod@4.1.2:
+    resolution: {integrity: sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  text-table@0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
+  tslib@2.3.1:
+    resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
+
+  tsutils@3.21.0:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+
+  typescript@4.4.4:
+    resolution: {integrity: sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@babel/runtime@7.24.7':
+    dependencies:
+      regenerator-runtime: 0.14.1
+
+  '@codemirror/state@6.4.1': {}
+
+  '@codemirror/view@6.27.0':
+    dependencies:
+      '@codemirror/state': 6.4.1
+      style-mod: 4.1.2
+      w3c-keyname: 2.2.8
+
+  '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
+    dependencies:
+      eslint: 8.57.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.10.1': {}
+
+  '@eslint/eslintrc@2.1.4':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.5
+      espree: 9.6.1
+      globals: 13.24.0
+      ignore: 5.3.1
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@8.57.0': {}
+
+  '@humanwhocodes/config-array@0.11.14':
+    dependencies:
+      '@humanwhocodes/object-schema': 2.0.3
+      debug: 4.3.5
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.17.1
+
+  '@ophidian/electron-types@24.3.1': {}
+
+  '@types/codemirror@5.60.8':
+    dependencies:
+      '@types/tern': 0.23.9
+
+  '@types/estree@1.0.5': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@20.14.2':
+    dependencies:
+      undici-types: 5.26.5
+
+  '@types/semver@7.5.8': {}
+
+  '@types/sortablejs@1.15.8': {}
+
+  '@types/tern@0.23.9':
+    dependencies:
+      '@types/estree': 1.0.5
+
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.4.4))(eslint@8.57.0)(typescript@4.4.4)':
+    dependencies:
+      '@eslint-community/regexpp': 4.10.1
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@4.4.4)
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@4.4.4)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@4.4.4)
+      debug: 4.3.5
+      eslint: 8.57.0
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      natural-compare-lite: 1.4.0
+      semver: 7.6.2
+      tsutils: 3.21.0(typescript@4.4.4)
+    optionalDependencies:
+      typescript: 4.4.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.4.4)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.4.4)
+      debug: 4.3.5
+      eslint: 8.57.0
+    optionalDependencies:
+      typescript: 4.4.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@5.62.0':
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
+
+  '@typescript-eslint/type-utils@5.62.0(eslint@8.57.0)(typescript@4.4.4)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.4.4)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@4.4.4)
+      debug: 4.3.5
+      eslint: 8.57.0
+      tsutils: 3.21.0(typescript@4.4.4)
+    optionalDependencies:
+      typescript: 4.4.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@5.62.0': {}
+
+  '@typescript-eslint/typescript-estree@5.62.0(typescript@4.4.4)':
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
+      debug: 4.3.5
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.6.2
+      tsutils: 3.21.0(typescript@4.4.4)
+    optionalDependencies:
+      typescript: 4.4.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@5.62.0(eslint@8.57.0)(typescript@4.4.4)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.8
+      '@typescript-eslint/scope-manager': 5.62.0
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.4.4)
+      eslint: 8.57.0
+      eslint-scope: 5.1.1
+      semver: 7.6.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/visitor-keys@5.62.0':
+    dependencies:
+      '@typescript-eslint/types': 5.62.0
+      eslint-visitor-keys: 3.4.3
+
+  '@ungap/structured-clone@1.2.0': {}
+
+  acorn-jsx@5.3.2(acorn@8.11.3):
+    dependencies:
+      acorn: 8.11.3
+
+  acorn@8.11.3: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  array-union@2.1.0: {}
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@1.1.11:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  builtin-modules@3.3.0: {}
+
+  callsites@3.1.0: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.3:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.3.5:
+    dependencies:
+      ms: 2.1.2
+
+  deep-is@0.1.4: {}
+
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
+
+  doctrine@3.0.0:
+    dependencies:
+      esutils: 2.0.3
+
+  esbuild-android-arm64@0.13.12:
+    optional: true
+
+  esbuild-darwin-64@0.13.12:
+    optional: true
+
+  esbuild-darwin-arm64@0.13.12:
+    optional: true
+
+  esbuild-freebsd-64@0.13.12:
+    optional: true
+
+  esbuild-freebsd-arm64@0.13.12:
+    optional: true
+
+  esbuild-linux-32@0.13.12:
+    optional: true
+
+  esbuild-linux-64@0.13.12:
+    optional: true
+
+  esbuild-linux-arm64@0.13.12:
+    optional: true
+
+  esbuild-linux-arm@0.13.12:
+    optional: true
+
+  esbuild-linux-mips64le@0.13.12:
+    optional: true
+
+  esbuild-linux-ppc64le@0.13.12:
+    optional: true
+
+  esbuild-netbsd-64@0.13.12:
+    optional: true
+
+  esbuild-openbsd-64@0.13.12:
+    optional: true
+
+  esbuild-sunos-64@0.13.12:
+    optional: true
+
+  esbuild-windows-32@0.13.12:
+    optional: true
+
+  esbuild-windows-64@0.13.12:
+    optional: true
+
+  esbuild-windows-arm64@0.13.12:
+    optional: true
+
+  esbuild@0.13.12:
+    optionalDependencies:
+      esbuild-android-arm64: 0.13.12
+      esbuild-darwin-64: 0.13.12
+      esbuild-darwin-arm64: 0.13.12
+      esbuild-freebsd-64: 0.13.12
+      esbuild-freebsd-arm64: 0.13.12
+      esbuild-linux-32: 0.13.12
+      esbuild-linux-64: 0.13.12
+      esbuild-linux-arm: 0.13.12
+      esbuild-linux-arm64: 0.13.12
+      esbuild-linux-mips64le: 0.13.12
+      esbuild-linux-ppc64le: 0.13.12
+      esbuild-netbsd-64: 0.13.12
+      esbuild-openbsd-64: 0.13.12
+      esbuild-sunos-64: 0.13.12
+      esbuild-windows-32: 0.13.12
+      esbuild-windows-64: 0.13.12
+      esbuild-windows-arm64: 0.13.12
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@5.1.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+
+  eslint-scope@7.2.2:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint@8.57.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@eslint-community/regexpp': 4.10.1
+      '@eslint/eslintrc': 2.1.4
+      '@eslint/js': 8.57.0
+      '@humanwhocodes/config-array': 0.11.14
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      '@ungap/structured-clone': 1.2.0
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.5
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.24.0
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+      strip-ansi: 6.0.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@9.6.1:
+    dependencies:
+      acorn: 8.11.3
+      acorn-jsx: 5.3.2(acorn@8.11.3)
+      eslint-visitor-keys: 3.4.3
+
+  esquery@1.5.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@4.3.0: {}
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.2:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.7
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fastq@1.17.1:
+    dependencies:
+      reusify: 1.0.4
+
+  file-entry-cache@6.0.1:
+    dependencies:
+      flat-cache: 3.2.0
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@3.2.0:
+    dependencies:
+      flatted: 3.3.1
+      keyv: 4.5.4
+      rimraf: 3.0.2
+
+  flatted@3.3.1: {}
+
+  fs.realpath@1.0.0: {}
+
+  fuse.js@6.6.2: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  globals@13.24.0:
+    dependencies:
+      type-fest: 0.20.2
+
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.2
+      ignore: 5.3.1
+      merge2: 1.4.1
+      slash: 3.0.0
+
+  graphemer@1.4.0: {}
+
+  has-flag@4.0.0: {}
+
+  i18next@21.10.0:
+    dependencies:
+      '@babel/runtime': 7.24.7
+
+  ignore@5.3.1: {}
+
+  import-fresh@3.3.0:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  is-path-inside@3.0.3: {}
+
+  isexe@2.0.0: {}
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.7:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.11
+
+  moment@2.29.4: {}
+
+  monkey-around@2.3.0: {}
+
+  ms@2.1.2: {}
+
+  natural-compare-lite@1.4.0: {}
+
+  natural-compare@1.4.0: {}
+
+  obsidian-typings@1.1.6(@ophidian/electron-types@24.3.1)(@types/node@20.14.2)(obsidian@1.5.7-1(@codemirror/state@6.4.1)(@codemirror/view@6.27.0)):
+    dependencies:
+      '@types/electron': '@ophidian/electron-types@24.3.1'
+      '@types/node': 20.14.2
+      obsidian: 1.5.7-1(@codemirror/state@6.4.1)(@codemirror/view@6.27.0)
+
+  obsidian@1.5.7-1(@codemirror/state@6.4.1)(@codemirror/view@6.27.0):
+    dependencies:
+      '@codemirror/state': 6.4.1
+      '@codemirror/view': 6.27.0
+      '@types/codemirror': 5.60.8
+      moment: 2.29.4
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-is-absolute@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-type@4.0.0: {}
+
+  picomatch@2.3.1: {}
+
+  prelude-ls@1.2.1: {}
+
+  punycode@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
+
+  regenerator-runtime@0.14.1: {}
+
+  resolve-from@4.0.0: {}
+
+  reusify@1.0.4: {}
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  semver@7.6.2: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  slash@3.0.0: {}
+
+  sortablejs@1.15.2: {}
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-json-comments@3.1.1: {}
+
+  style-mod@4.1.2: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  text-table@0.2.0: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  tslib@1.14.1: {}
+
+  tslib@2.3.1: {}
+
+  tsutils@3.21.0(typescript@4.4.4):
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.4.4
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  type-fest@0.20.2: {}
+
+  typescript@4.4.4: {}
+
+  undici-types@5.26.5: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  w3c-keyname@2.2.8: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  wrappy@1.0.2: {}
+
+  yocto-queue@0.1.0: {}

--- a/src/file-explorer/custom-sort.ts
+++ b/src/file-explorer/custom-sort.ts
@@ -1,10 +1,4 @@
-import {
-  Menu,
-  type TAbstractFile,
-  type TFile,
-  TFolder,
-  setIcon,
-} from "obsidian";
+import { Menu, TAbstractFile, TFile, TFolder, setIcon } from "obsidian";
 import type { BartenderSettings } from "../settings/settings";
 
 const Collator = new Intl.Collator(undefined, {

--- a/src/file-explorer/custom-sort.ts
+++ b/src/file-explorer/custom-sort.ts
@@ -1,5 +1,5 @@
 import Fuse from "fuse.js";
-import {Menu, TAbstractFile, TFile, TFolder, requireApiVersion, FileExplorerView, sanitizeHTMLToDom} from "obsidian";
+import {Menu, TAbstractFile, TFile, TFolder, requireApiVersion, FileExplorerView, sanitizeHTMLToDom, setIcon} from "obsidian";
 import {BartenderSettings} from "../settings/settings";
 
 let Collator = new Intl.Collator(undefined, {
@@ -31,11 +31,6 @@ let Sorter = {
 
 const Translate = i18next.t.bind(i18next);
 
-const SortGlyph = "arrow-up-narrow-wide";
-
-const MOVE_ICON = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-move svg-icon"><polyline points="5 9 2 12 5 15"/><polyline points="9 5 12 2 15 5"/><polyline points="15 19 12 22 9 19"/><polyline points="19 9 22 12 19 15"/><line x1="2" x2="22" y1="12" y2="12"/><line x1="12" x2="12" y1="2" y2="22"/></svg>'
-
-const DEFAULT_ICON = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-up-narrow-wide svg-icon"><path d="m3 8 4-4 4 4"/><path d="M7 4v16"/><path d="M11 12h4"/><path d="M11 16h7"/><path d="M11 20h10"/></svg>';
 
 const sortOptionStrings = {
   alphabetical: "plugins.file-explorer.label-sort-a-to-z",
@@ -114,23 +109,8 @@ export const addSortButton = function (settings:BartenderSettings, sorter: any, 
                       plugin.app.workspace.trigger("file-explorer-sort-change", _sortOption);
                     }
                     setSortOrder(_sortOption);
-                    if (_sortOption === "custom") {
-                      const svg = sortEl.querySelector("svg");
-                      if (svg) {
-                        svg.remove();
-                        sortEl.appendChild(
-                          sanitizeHTMLToDom(MOVE_ICON)
-                        );
-                      }
-                    } else {
-                      const svg = sortEl.querySelector("svg");
-                      if (svg) {
-                        svg.remove();
-                        sortEl.appendChild(
-                          sanitizeHTMLToDom(DEFAULT_ICON))
-                      }
-                    }
-                    
+                    if (_sortOption === "custom") setIcon(sortEl, "move");
+                    else setIcon(sortEl, "arrow-up-narrow-wide");
                   });
               });
             },

--- a/src/file-explorer/custom-sort.ts
+++ b/src/file-explorer/custom-sort.ts
@@ -1,36 +1,40 @@
-import Fuse from "fuse.js";
-import {Menu, TAbstractFile, TFile, TFolder, requireApiVersion, FileExplorerView, sanitizeHTMLToDom, setIcon} from "obsidian";
-import {BartenderSettings} from "../settings/settings";
+import {
+  Menu,
+  type TAbstractFile,
+  type TFile,
+  TFolder,
+  setIcon,
+} from "obsidian";
+import type { BartenderSettings } from "../settings/settings";
 
-let Collator = new Intl.Collator(undefined, {
+const Collator = new Intl.Collator(undefined, {
   usage: "sort",
   sensitivity: "base",
   numeric: true,
 }).compare;
 
-let Sorter = {
-  alphabetical: function (first: TFile, second: TFile) {
+const Sorter = {
+  alphabetical(first: TFile, second: TFile) {
     return Collator(first.basename, second.basename);
   },
-  alphabeticalReverse: function (first: TFile, second: TFile) {
+  alphabeticalReverse(first: TFile, second: TFile) {
     return -Sorter.alphabetical(first, second);
   },
-  byModifiedTime: function (first: TFile, second: TFile) {
+  byModifiedTime(first: TFile, second: TFile) {
     return second.stat.mtime - first.stat.mtime;
   },
-  byModifiedTimeReverse: function (first: TFile, second: TFile) {
+  byModifiedTimeReverse(first: TFile, second: TFile) {
     return -Sorter.byModifiedTime(first, second);
   },
-  byCreatedTime: function (first: TFile, second: TFile) {
+  byCreatedTime(first: TFile, second: TFile) {
     return second.stat.ctime - first.stat.ctime;
   },
-  byCreatedTimeReverse: function (first: TFile, second: TFile) {
+  byCreatedTimeReverse(first: TFile, second: TFile) {
     return -Sorter.byCreatedTime(first, second);
   },
 };
 
 const Translate = i18next.t.bind(i18next);
-
 
 const sortOptionStrings = {
   alphabetical: "plugins.file-explorer.label-sort-a-to-z",
@@ -49,77 +53,108 @@ const sortOptionGroups = [
   ["custom"],
 ];
 
-export const folderSort = function (order: string[], foldersOnBottom?: boolean) {
-  let fileExplorer = this.view,
-    folderContents = this.file.children.slice();
-  folderContents.sort(function (firstEl: TFile | TFolder, secondEl: TFile | TFolder) {
-    let firstIsFolder, secondIsFolder;
+/**
+ * For the moment, we copy the original function
+ * Will be modify to add the custom sort after, but first I need to understand how it works
+ * @param e
+ */
+export const folderSortV2 = function (
+  settings: BartenderSettings,
+  e: any,
+  foldersOnBottom?: boolean
+) {
+  const children = e.children.slice();
+  children.sort((firstEl: TAbstractFile, secondEl: TAbstractFile) => {
+    let firstIsFolder;
+    let secondIsFolder;
     if (
       foldersOnBottom &&
-      ((firstIsFolder = firstEl instanceof TFolder) || (secondIsFolder = secondEl instanceof TFolder))
+      ((firstIsFolder = firstEl instanceof TFolder) ||
+        (secondIsFolder = secondEl instanceof TFolder))
     ) {
       return firstIsFolder && !secondIsFolder
         ? 1
         : secondIsFolder && !firstIsFolder
         ? -1
         : Collator(firstEl.name, secondEl.name);
-    } else {
-      if (!order) return Collator(firstEl.name, secondEl.name);
-
-      const index1 = order.indexOf(firstEl.path);
-      const index2 = order.indexOf(secondEl.path);
-
-      return (index1 > -1 ? index1 : Infinity) - (index2 > -1 ? index2 : Infinity);
     }
-  });
-  const items = folderContents
-    .map((child: TAbstractFile) => fileExplorer.fileItems[child.path])
-    .filter((f: TAbstractFile) => f);
 
-  if (requireApiVersion && requireApiVersion("0.15.0")) {
-    this.vChildren.setChildren(items);
-  } else {
-    this.children = items;
+    const order =
+      firstEl.parent &&
+      secondEl.parent &&
+      firstEl.parent === secondEl.parent &&
+      !firstEl.parent.isRoot()
+        ? settings.fileExplorerOrder[firstEl.parent.path] || undefined
+        : settings.fileExplorerOrder[""];
+    if (!order) return Collator(firstEl.name, secondEl.name);
+    const index1 = order.indexOf(firstEl.path);
+    const index2 = order.indexOf(secondEl.path);
+
+    return (
+      (index1 > -1 ? index1 : Infinity) - (index2 > -1 ? index2 : Infinity)
+    );
+  });
+  const i = [];
+  for (let r = 0, o = children; r < o.length; r++) {
+    const a = o[r];
+    const s = this.fileItems[a.path];
+    s && i.push(s);
   }
+
+  return i;
 };
 
-export const addSortButton = function (settings:BartenderSettings, sorter: any, sortOption: any,setSortOrder:any,currentSort:any) {
-  let plugin = this;
-  let sortEl = this.addNavButton(
+export const addSortButton = function (
+  settings: BartenderSettings,
+  sorter: any,
+  sortOption: any,
+  setSortOrder: any,
+  currentSort: any
+) {
+  const plugin = this;
+  const sortEl = this.addNavButton(
     settings.sortOrder === "custom" ? "move" : "arrow-up-narrow-wide",
     Translate("plugins.file-explorer.action-change-sort"),
-    function (event: MouseEvent) {
+    (event: MouseEvent) => {
       event.preventDefault();
-      let menu = new Menu();
+      const menu = new Menu();
       for (
-        let currentSortOption = settings.sortOrder, groupIndex = 0, _sortOptionGroups = sortOptionGroups;
+        let currentSortOption = settings.sortOrder,
+          groupIndex = 0,
+          _sortOptionGroups = sortOptionGroups;
         groupIndex < _sortOptionGroups.length;
         groupIndex++
       ) {
         for (
-          let addMenuItem = function (_sortOption: keyof typeof sortOptionStrings) {
-              let label = Translate(sortOptionStrings[_sortOption]);
-              menu.addItem(function (item) {
-                return item
+          let addMenuItem = (_sortOption: keyof typeof sortOptionStrings) => {
+              const label = Translate(sortOptionStrings[_sortOption]);
+              menu.addItem((item) =>
+                item
                   .setTitle(label)
-                  .setActive(_sortOption === currentSortOption)
-                  .onClick(function () {
+                  .setChecked(_sortOption === currentSortOption)
+                  .onClick(() => {
+                    console.log(_sortOption, currentSortOption);
                     if (_sortOption !== currentSortOption) {
                       sortEl.setAttribute("data-sort-method", _sortOption);
-                      plugin.app.workspace.trigger("file-explorer-sort-change", _sortOption);
+                      plugin.app.workspace.trigger(
+                        "file-explorer-sort-change",
+                        _sortOption
+                      );
                     }
                     setSortOrder(_sortOption);
                     if (_sortOption === "custom") setIcon(sortEl, "move");
                     else setIcon(sortEl, "arrow-up-narrow-wide");
-                  });
-              });
+                  })
+              );
             },
             itemIndex = 0,
             sortOptionGroup = _sortOptionGroups[groupIndex];
           itemIndex < sortOptionGroup.length;
           itemIndex++
         ) {
-          addMenuItem(sortOptionGroup[itemIndex] as keyof typeof sortOptionStrings);
+          addMenuItem(
+            sortOptionGroup[itemIndex] as keyof typeof sortOptionStrings
+          );
         }
         menu.addSeparator();
       }
@@ -129,17 +164,21 @@ export const addSortButton = function (settings:BartenderSettings, sorter: any, 
   setTimeout(() => {
     sortEl.setAttribute("data-sort-method", settings.sortOrder);
   }, 100);
-  this.addNavButton("three-horizontal-bars", "Drag to rearrange", function (event: MouseEvent) {
-    event.preventDefault();
-    let value = !this.hasClass("is-active");
-    this.toggleClass("is-active", value);
-    plugin.app.workspace.trigger("file-explorer-draggable-change", value);
-  }).addClass("drag-to-rearrange");
+  this.addNavButton(
+    "three-horizontal-bars",
+    "Drag to rearrange",
+    function (event: MouseEvent) {
+      event.preventDefault();
+      const value = !this.hasClass("is-active");
+      this.toggleClass("is-active", value);
+      plugin.app.workspace.trigger("file-explorer-draggable-change", value);
+    }
+  ).addClass("drag-to-rearrange");
   this.addNavButton("search", "Filter items", function (event: MouseEvent) {
     event.preventDefault();
-    let value = !this.hasClass("is-active");
+    const value = !this.hasClass("is-active");
     this.toggleClass("is-active", value);
-    let filterEl = document.body.querySelector(
+    const filterEl = document.body.querySelector(
       '.workspace-leaf-content[data-type="file-explorer"] .search-input-container > input'
     ) as HTMLInputElement;
 

--- a/src/file-explorer/custom-sort.ts
+++ b/src/file-explorer/custom-sort.ts
@@ -1,5 +1,5 @@
 import Fuse from "fuse.js";
-import {Menu, TAbstractFile, TFile, TFolder, requireApiVersion, FileExplorerView} from "obsidian";
+import {Menu, TAbstractFile, TFile, TFolder, requireApiVersion, FileExplorerView, sanitizeHTMLToDom} from "obsidian";
 import {BartenderSettings} from "../settings/settings";
 
 let Collator = new Intl.Collator(undefined, {
@@ -31,7 +31,11 @@ let Sorter = {
 
 const Translate = i18next.t.bind(i18next);
 
-const SortGlyph = "up-and-down-arrows";
+const SortGlyph = "arrow-up-narrow-wide";
+
+const MOVE_ICON = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-move svg-icon"><polyline points="5 9 2 12 5 15"/><polyline points="9 5 12 2 15 5"/><polyline points="15 19 12 22 9 19"/><polyline points="19 9 22 12 19 15"/><line x1="2" x2="22" y1="12" y2="12"/><line x1="12" x2="12" y1="2" y2="22"/></svg>'
+
+const DEFAULT_ICON = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-up-narrow-wide svg-icon"><path d="m3 8 4-4 4 4"/><path d="M7 4v16"/><path d="M11 12h4"/><path d="M11 16h7"/><path d="M11 20h10"/></svg>';
 
 const sortOptionStrings = {
   alphabetical: "plugins.file-explorer.label-sort-a-to-z",
@@ -87,7 +91,7 @@ export const folderSort = function (order: string[], foldersOnBottom?: boolean) 
 export const addSortButton = function (settings:BartenderSettings, sorter: any, sortOption: any,setSortOrder:any,currentSort:any) {
   let plugin = this;
   let sortEl = this.addNavButton(
-    SortGlyph,
+    settings.sortOrder === "custom" ? "move" : "arrow-up-narrow-wide",
     Translate("plugins.file-explorer.action-change-sort"),
     function (event: MouseEvent) {
       event.preventDefault();
@@ -110,6 +114,23 @@ export const addSortButton = function (settings:BartenderSettings, sorter: any, 
                       plugin.app.workspace.trigger("file-explorer-sort-change", _sortOption);
                     }
                     setSortOrder(_sortOption);
+                    if (_sortOption === "custom") {
+                      const svg = sortEl.querySelector("svg");
+                      if (svg) {
+                        svg.remove();
+                        sortEl.appendChild(
+                          sanitizeHTMLToDom(MOVE_ICON)
+                        );
+                      }
+                    } else {
+                      const svg = sortEl.querySelector("svg");
+                      if (svg) {
+                        svg.remove();
+                        sortEl.appendChild(
+                          sanitizeHTMLToDom(DEFAULT_ICON))
+                      }
+                    }
+                    
                   });
               });
             },

--- a/src/file-explorer/custom-sort.ts
+++ b/src/file-explorer/custom-sort.ts
@@ -1,5 +1,6 @@
 import Fuse from "fuse.js";
-import { Menu, TAbstractFile, TFile, TFolder, requireApiVersion } from "obsidian";
+import {Menu, TAbstractFile, TFile, TFolder, requireApiVersion, FileExplorerView} from "obsidian";
+import {BartenderSettings} from "../settings/settings";
 
 let Collator = new Intl.Collator(undefined, {
   usage: "sort",
@@ -50,7 +51,7 @@ const sortOptionGroups = [
 ];
 
 export const folderSort = function (order: string[], foldersOnBottom?: boolean) {
-  let fileExplorer = this.fileExplorer,
+  let fileExplorer = this.view,
     folderContents = this.file.children.slice();
   folderContents.sort(function (firstEl: TFile | TFolder, secondEl: TFile | TFolder) {
     let firstIsFolder, secondIsFolder;
@@ -83,16 +84,16 @@ export const folderSort = function (order: string[], foldersOnBottom?: boolean) 
   }
 };
 
-export const addSortButton = function (sorter: any, sortOption: any) {
+export const addSortButton = function (settings:BartenderSettings, sorter: any, sortOption: any,setSortOrder:any,currentSort:any) {
   let plugin = this;
   let sortEl = this.addNavButton(
     SortGlyph,
     Translate("plugins.file-explorer.action-change-sort"),
     function (event: MouseEvent) {
       event.preventDefault();
-      let menu = new Menu(plugin.app);
+      let menu = new Menu();
       for (
-        let currentSortOption = sortOption(), groupIndex = 0, _sortOptionGroups = sortOptionGroups;
+        let currentSortOption = settings.sortOrder, groupIndex = 0, _sortOptionGroups = sortOptionGroups;
         groupIndex < _sortOptionGroups.length;
         groupIndex++
       ) {
@@ -108,7 +109,7 @@ export const addSortButton = function (sorter: any, sortOption: any) {
                       sortEl.setAttribute("data-sort-method", _sortOption);
                       plugin.app.workspace.trigger("file-explorer-sort-change", _sortOption);
                     }
-                    sorter(_sortOption);
+                    setSortOrder(_sortOption);
                   });
               });
             },
@@ -125,7 +126,7 @@ export const addSortButton = function (sorter: any, sortOption: any) {
     }
   );
   setTimeout(() => {
-    sortEl.setAttribute("data-sort-method", sortOption());
+    sortEl.setAttribute("data-sort-method", settings.sortOrder);
   }, 100);
   this.addNavButton("three-horizontal-bars", "Drag to rearrange", function (event: MouseEvent) {
     event.preventDefault();

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,44 @@ export default class BartenderPlugin extends Plugin {
     this.registerEventHandlers();
     this.registerSettingsTab();
     this.initialize();
+
+		this.app.vault.on("rename", async (file, oldFile) => {
+			// change the path in the settings
+			//first check if folder and search this path in the settings
+			console.log("file", file, "oldFile", oldFile);
+			for (const key in this.settings.fileExplorerOrder) {
+				for (const item of this.settings.fileExplorerOrder[key]) {
+					if (item === oldFile) {
+						const index = this.settings.fileExplorerOrder[key].indexOf(item);
+						this.settings.fileExplorerOrder[key][index] = file.path;
+					}
+				}
+				if (key.startsWith(oldFile)) {
+					this.settings.fileExplorerOrder[file.path] =
+						this.settings.fileExplorerOrder[key];
+					delete this.settings.fileExplorerOrder[key];
+				}
+			}
+			await this.saveSettings();
+		});
+
+		this.app.vault.on("delete", async (file) => {
+			// remove the path from the settings
+			console.log("file", file);
+			for (const key in this.settings.fileExplorerOrder) {
+				for (const item of this.settings.fileExplorerOrder[key]) {
+					if (item === file.path) {
+						const index = this.settings.fileExplorerOrder[key].indexOf(item);
+						console.log("index", index);
+						this.settings.fileExplorerOrder[key].splice(index, 1);
+					}
+				}
+				if (key.startsWith(file.path)) {
+					delete this.settings.fileExplorerOrder[key];
+				}
+			}
+			await this.saveSettings();
+		});
   }
 
   async loadSettings() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,925 +1,905 @@
 import Fuse from "fuse.js";
 import { around } from "monkey-around";
 import {
-	ChildElement,
-	Component,
-	FileExplorerHeader,
-	FileExplorerView,
-	Platform,
-	Plugin,
-	RootElements,
-	Scope,
-	setIcon,
-	SplitDirection,
-	TFolder,
-	Vault,
-	View,
-	ViewCreator,
-	Workspace,
-	WorkspaceItem,
-	WorkspaceLeaf,
-	WorkspaceSplit,
-	WorkspaceTabs,
-	requireApiVersion,
+  ChildElement,
+  FileExplorerHeader,
+  FileExplorerView,
+  Platform,
+  Plugin,
+  RootElements,
+  Scope,
+  setIcon,
+  SplitDirection,
+  TFolder,
+  Vault,
+  View,
+  ViewCreator,
+  Workspace,
+  WorkspaceItem,
+  WorkspaceLeaf,
+  WorkspaceSplit,
+  WorkspaceTabs,
+  requireApiVersion,
 } from "obsidian";
 
 import Sortable, { MultiDrag } from "sortablejs";
 import { addSortButton, folderSort } from "./file-explorer/custom-sort";
 import {
-	BartenderSettings,
-	DEFAULT_SETTINGS,
-	SettingTab,
+  BartenderSettings,
+  DEFAULT_SETTINGS,
+  SettingTab,
 } from "./settings/settings";
 import {
-	generateId,
-	GenerateIdOptions,
-	getFn,
-	getItems,
-	getNextSiblings,
-	getPreviousSiblings,
-	highlight,
-	reorderArray,
+  generateId,
+  GenerateIdOptions,
+  getFn,
+  getItems,
+  getNextSiblings,
+  getPreviousSiblings,
+  highlight,
+  reorderArray,
 } from "./utils";
 
 Sortable.mount(new MultiDrag());
 
 const STATUS_BAR_SELECTOR = "body > div.app-container div.status-bar";
 const RIBBON_BAR_SELECTOR = "body > div.app-container div.side-dock-actions";
-const DRAG_DELAY = Platform.isMobile ? 200 : 200;
 const ANIMATION_DURATION = 500;
 
 export default class BartenderPlugin extends Plugin {
-	statusBarSorter: Sortable;
-	ribbonBarSorter: Sortable;
-	fileSorter: Sortable;
-	separator: HTMLElement;
-	settings: BartenderSettings;
-	settingsTab: SettingTab;
+  statusBarSorter: Sortable;
+  ribbonBarSorter: Sortable;
+  fileSorter: Sortable;
+  separator: HTMLElement;
+  settings: BartenderSettings;
+  settingsTab: SettingTab;
 
-	async onload() {
-		await this.loadSettings();
-		this.registerMonkeyPatches();
-		this.registerEventHandlers();
-		this.registerSettingsTab();
-		this.initialize();
-	}
+  async onload() {
+    await this.loadSettings();
+    this.registerMonkeyPatches();
+    this.registerEventHandlers();
+    this.registerSettingsTab();
+    this.initialize();
+  }
 
-	async loadSettings() {
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-	}
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
 
-	async saveSettings() {
-		await this.saveData(this.settings);
-	}
+  async saveSettings() {
+    await this.saveData(this.settings);
+  }
 
-	patchFileExplorerFolder() {
-		let plugin = this;
-		let leaf = plugin.app.workspace.getLeaf(true);
-		let fileExplorer = plugin.app.viewRegistry.viewByType["file-explorer"](
-			leaf,
-		) as FileExplorerView;
-		// @ts-ignore
-		let tmpFolder = new TFolder(Vault, "");
-		let Folder = fileExplorer.createFolderDom(tmpFolder).constructor;
-		this.register(
-			around(Folder.prototype, {
-				sort(old: any) {
-					return function (...args: any[]) {
-						let order = plugin.settings.fileExplorerOrder[this.file.path];
-						if (plugin.settings.sortOrder === "custom") {
-							return folderSort.call(this, order, ...args);
-						} else {
-							return old.call(this, ...args);
-						}
-					};
-				},
-			}),
-		);
-		leaf.detach();
-	}
+  patchFileExplorerFolder() {
+    const plugin = this;
+    const leaf = plugin.app.workspace.getLeaf(true);
+    const fileExplorer = plugin.app.viewRegistry.viewByType["file-explorer"](
+      leaf
+    ) as FileExplorerView;
+    // @ts-ignore
+    const tmpFolder = new TFolder(Vault, "");
+    const Folder = fileExplorer.createFolderDom(tmpFolder).constructor;
+    this.register(
+      around(Folder.prototype, {
+        sort(old: any) {
+          return function (...args: any[]) {
+            const order = plugin.settings.fileExplorerOrder[this.file.path];
+            return plugin.settings.sortOrder === "custom"
+              ? folderSort.call(this, order, ...args)
+              : old.call(this, ...args);
+          };
+        },
+      })
+    );
+    leaf.detach();
+  }
 
-	initialize() {
-		this.app.workspace.onLayoutReady(() => {
-			this.patchFileExplorerFolder();
-			setTimeout(
-				() => {
-					if (Platform.isDesktop) {
-						// add sorter to the status bar
-						this.insertSeparator(
-							STATUS_BAR_SELECTOR,
-							"status-bar-item",
-							true,
-							16,
-						);
-						this.setStatusBarSorter();
+  initialize() {
+    this.app.workspace.onLayoutReady(() => {
+      this.patchFileExplorerFolder();
+      setTimeout(
+        () => {
+          if (Platform.isDesktop) {
+            // add sorter to the status bar
+            this.insertSeparator(STATUS_BAR_SELECTOR, "status-bar-item", true);
+            this.setStatusBarSorter();
 
-						// add sorter to the sidebar tabs
-						if (requireApiVersion && !requireApiVersion("0.15.3")) {
-							let left = (this.app.workspace.leftSplit as WorkspaceSplit)
-								.children;
-							let right = (this.app.workspace.rightSplit as WorkspaceSplit)
-								.children;
-							left.concat(right).forEach((child) => {
-								if (child.hasOwnProperty("tabsInnerEl") && !child.iconSorter) {
-									child.iconSorter = this.setTabBarSorter(
-										child.tabsInnerEl,
-										child,
-									);
-								}
-							});
-						}
-					}
+            // add sorter to the sidebar tabs
+            if (requireApiVersion && !requireApiVersion("0.15.3")) {
+              const left = (this.app.workspace.leftSplit as WorkspaceSplit)
+                .children;
+              const right = (this.app.workspace.rightSplit as WorkspaceSplit)
+                .children;
+              left.concat(right).forEach((child) => {
+                if (child.hasOwnProperty("tabsInnerEl") && !child.iconSorter) {
+                  child.iconSorter = this.setTabBarSorter(
+                    child.tabsInnerEl,
+                    child
+                  );
+                }
+              });
+            }
+          }
 
-					// add file explorer sorter
-					this.setFileExplorerSorter();
+          // add file explorer sorter
+          this.setFileExplorerSorter();
 
-					// add sorter to the left sidebar ribbon
-					this.insertSeparator(
-						RIBBON_BAR_SELECTOR,
-						"side-dock-ribbon-action",
-						false,
-						18,
-					);
-					this.setRibbonBarSorter();
+          // add sorter to the left sidebar ribbon
+          this.insertSeparator(
+            RIBBON_BAR_SELECTOR,
+            "side-dock-ribbon-action",
+            false
+          );
+          this.setRibbonBarSorter();
 
-					// add sorter to all view actions icon groups
-					this.app.workspace.iterateRootLeaves((leaf) => {
-						if (
-							leaf?.view?.hasOwnProperty("actionsEl") &&
-							!leaf?.view?.hasOwnProperty("iconSorter")
-						) {
-							leaf.view.iconSorter = this.setViewActionSorter(
-								leaf.view.actionsEl,
-								leaf.view,
-							);
-						}
-					});
-				},
-				Platform.isMobile ? 3000 : 400,
-			); // give time for plugins like Customizable Page Header to add their icons
-		});
-	}
+          // add sorter to all view actions icon groups
+          this.app.workspace.iterateRootLeaves((leaf) => {
+            if (
+              leaf?.view?.hasOwnProperty("actionsEl") &&
+              !leaf?.view?.hasOwnProperty("iconSorter")
+            ) {
+              leaf.view.iconSorter = this.setViewActionSorter(
+                leaf.view.actionsEl,
+                leaf.view
+              );
+            }
+          });
+        },
+        Platform.isMobile ? 3000 : 400
+      ); // give time for plugins like Customizable Page Header to add their icons
+    });
+  }
 
-	registerSettingsTab() {
-		this.settingsTab = new SettingTab(this.app, this);
-		this.addSettingTab(this.settingsTab);
-	}
+  registerSettingsTab() {
+    this.settingsTab = new SettingTab(this.app, this);
+    this.addSettingTab(this.settingsTab);
+  }
 
-	clearFileExplorerFilter() {
-		const fileExplorer = this.getFileExplorer();
-		let fileExplorerFilterEl: HTMLInputElement | null =
-			document.body.querySelector(
-				'.workspace-leaf-content[data-type="file-explorer"] .search-input-container > input',
-			);
-		fileExplorerFilterEl && (fileExplorerFilterEl.value = "");
-		fileExplorer.tree.infinityScroll.filter = "";
-		fileExplorer.tree.infinityScroll.compute();
-	}
+  clearFileExplorerFilter() {
+    const fileExplorer = this.getFileExplorer();
+    const fileExplorerFilterEl: HTMLInputElement | null =
+      document.body.querySelector(
+        '.workspace-leaf-content[data-type="file-explorer"] .search-input-container > input'
+      );
+    if (fileExplorerFilterEl) fileExplorerFilterEl.value = "";
+    fileExplorer.tree.infinityScroll.filter = "";
+    fileExplorer.tree.infinityScroll.compute();
+  }
 
-	fileExplorerFilter = function (fileExplorer: FileExplorerView) {
-		const supportsVirtualChildren =
-			requireApiVersion && requireApiVersion("0.15.0");
-		/*    let leaf = this?.rootEl?.view?.app.workspace.getLeaf(true);
+  fileExplorerFilter = function (fileExplorer: FileExplorerView) {
+    const supportsVirtualChildren = requireApiVersion?.("0.15.0");
+    /*    let leaf = this?.rootEl?.view?.app.workspace.getLeaf(true);
     let fileExplorer = this?.rootEl?.view?.app.viewRegistry.viewByType["file-explorer"](leaf) as FileExplorerView;*/
 
-		//let fileExplorer = this?.rootEl?.fileExplorer;
+    //let fileExplorer = this?.rootEl?.fileExplorer;
 
-		if (!fileExplorer) return;
-		const _children = supportsVirtualChildren
-			? this.rootEl?.vChildren._children
-			: this.rootEl?.children;
-		if (!_children) return;
-		if (this.filter?.length >= 1) {
-			if (!this.filtered) {
-				this.rootEl._children = _children;
-				this.filtered = true;
-			}
-			const options = {
-				includeScore: true,
-				includeMatches: true,
-				useExtendedSearch: true,
-				getFn: getFn,
-				threshold: 0.1,
-				ignoreLocation: true,
-				keys: ["file.path"],
-			};
-			let flattenedItems = getItems(this.rootEl._children);
-			const fuse = new Fuse(flattenedItems, options);
-			const maxResults = 200;
-			let results = fuse.search(this.filter).slice(0, maxResults);
-			if (supportsVirtualChildren) {
-				this.rootEl.vChildren._children = highlight(results);
-			} else {
-				this.rootEl.children = highlight(results);
-			}
-		} else if (this.filter?.length < 1 && this.filtered) {
-			if (this.rootEl._children) {
-				if (supportsVirtualChildren) {
-					this.rootEl.vChildren._children = this.rootEl._children;
-				} else {
-					this.rootEl.children = this.rootEl._children;
-				}
-			}
+    if (!fileExplorer) return;
+    const _children = supportsVirtualChildren
+      ? this.rootEl?.vChildren._children
+      : this.rootEl?.children;
+    if (!_children) return;
+    if (this.filter?.length >= 1) {
+      if (!this.filtered) {
+        this.rootEl._children = _children;
+        this.filtered = true;
+      }
+      const options = {
+        includeScore: true,
+        includeMatches: true,
+        useExtendedSearch: true,
+        getFn,
+        threshold: 0.1,
+        ignoreLocation: true,
+        keys: ["file.path"],
+      };
+      const flattenedItems = getItems(this.rootEl._children);
+      const fuse = new Fuse(flattenedItems, options);
+      const maxResults = 200;
+      const results = fuse.search(this.filter).slice(0, maxResults);
+      if (supportsVirtualChildren) {
+        this.rootEl.vChildren._children = highlight(results);
+      } else {
+        this.rootEl.children = highlight(results);
+      }
+      return;
+    }
+    if (!(this.filter?.length < 1 && this.filtered)) {
+      return;
+    }
+    if (this.rootEl._children) {
+      if (supportsVirtualChildren) {
+        this.rootEl.vChildren._children = this.rootEl._children;
+      } else {
+        this.rootEl.children = this.rootEl._children;
+      }
+    }
 
-			let flattenedItems = getItems(this.rootEl._children);
-			flattenedItems.map((match: ChildElement) => {
-				if ((<any>match).innerEl.origContent) {
-					match.innerEl.setText((<any>match).innerEl.origContent);
-					delete (<any>match).innerEl.origContent;
-					match.innerEl.removeClass("has-matches");
-				}
-			});
+    const flattenedItems = getItems(this.rootEl._children);
+    flattenedItems.map((match: ChildElement) => {
+      if (!(<any>match).innerEl.origContent) {
+        return;
+      }
+      // @ts-ignore
+      match.innerEl.setText((<any>match).innerEl.origContent);
+      delete (<any>match).innerEl.origContent;
+      // @ts-ignore
+      match.innerEl.removeClass("has-matches");
+    });
 
-			this.filtered = false;
-		}
-	};
+    this.filtered = false;
+  };
 
-	registerEventHandlers() {
-		this.registerEvent(
-			this.app.workspace.on("file-explorer-draggable-change", (value) => {
-				this.toggleFileExplorerSorters(value);
-			}),
-		);
-		this.registerEvent(
-			this.app.workspace.on(
-				"file-explorer-sort-change",
-				(sortMethod: string) => {
-					this.settings.sortOrder = sortMethod;
-					this.saveSettings();
-					if (sortMethod === "custom") {
-						setTimeout(() => {
-							this.setFileExplorerSorter();
-						}, 10);
-					} else {
-						this.cleanupFileExplorerSorters();
-					}
-				},
-			),
-		);
-		this.registerEvent(
-			this.app.workspace.on(
-				"file-explorer-load",
-				(fileExplorer: FileExplorerView) => {
-					setTimeout(() => {
-						this.setFileExplorerSorter(fileExplorer);
-					}, 1000);
-				},
-			),
-		);
-		this.registerEvent(
-			this.app.workspace.on(
-				"bartender-leaf-split",
-				(originLeaf: WorkspaceItem, newLeaf: WorkspaceItem) => {
-					let element: HTMLElement = newLeaf.tabsInnerEl as HTMLElement;
-					if (newLeaf.type === "tabs" && newLeaf instanceof WorkspaceTabs) {
-						if (requireApiVersion && !requireApiVersion("0.15.3")) {
-							this.setTabBarSorter(element, newLeaf);
-						}
-					}
-				},
-			),
-		);
+  registerEventHandlers() {
+    this.registerEvent(
+      this.app.workspace.on("file-explorer-draggable-change", (value) => {
+        this.toggleFileExplorerSorters(value);
+      })
+    );
+    this.registerEvent(
+      this.app.workspace.on(
+        "file-explorer-sort-change",
+        (sortMethod: string) => {
+          this.settings.sortOrder = sortMethod;
+          this.saveSettings();
+          if (sortMethod === "custom") {
+            setTimeout(() => {
+              this.setFileExplorerSorter();
+            }, 10);
+          } else {
+            this.cleanupFileExplorerSorters();
+          }
+        }
+      )
+    );
+    this.registerEvent(
+      this.app.workspace.on(
+        "file-explorer-load",
+        (fileExplorer: FileExplorerView) => {
+          setTimeout(() => {
+            this.setFileExplorerSorter(fileExplorer);
+          }, 1000);
+        }
+      )
+    );
+    this.registerEvent(
+      this.app.workspace.on(
+        "bartender-leaf-split",
+        (_originLeaf: WorkspaceItem, newLeaf: WorkspaceItem) => {
+          const element: HTMLElement = newLeaf.tabsInnerEl as HTMLElement;
+          if (newLeaf.type === "tabs" && newLeaf instanceof WorkspaceTabs) {
+            if (requireApiVersion && !requireApiVersion("0.15.3")) {
+              this.setTabBarSorter(element, newLeaf);
+            }
+          }
+        }
+      )
+    );
 
-		this.registerEvent(
-			this.app.workspace.on("ribbon-bar-updated", () => {
-				setTimeout(() => {
-					if (this.settings.ribbonBarOrder && this.ribbonBarSorter) {
-						this.setElementIDs(this.ribbonBarSorter.el, {
-							useClass: true,
-							useAria: true,
-							useIcon: true,
-						});
-						this.ribbonBarSorter.sort(this.settings.ribbonBarOrder);
-					}
-				}, 0);
-			}),
-		);
-		this.registerEvent(
-			this.app.workspace.on("status-bar-updated", () => {
-				setTimeout(() => {
-					if (this.settings.statusBarOrder && this.statusBarSorter) {
-						this.setElementIDs(this.statusBarSorter.el, {
-							useClass: true,
-							useIcon: true,
-						});
-						this.statusBarSorter.sort(this.settings.statusBarOrder);
-					}
-				}, 0);
-			}),
-		);
-	}
+    this.registerEvent(
+      this.app.workspace.on("ribbon-bar-updated", () => {
+        setTimeout(() => {
+          if (this.settings.ribbonBarOrder && this.ribbonBarSorter) {
+            this.setElementIDs(this.ribbonBarSorter.el, {
+              useClass: true,
+              useAria: true,
+              useIcon: true,
+            });
+            this.ribbonBarSorter.sort(this.settings.ribbonBarOrder);
+          }
+        }, 0);
+      })
+    );
+    this.registerEvent(
+      this.app.workspace.on("status-bar-updated", () => {
+        setTimeout(() => {
+          if (this.settings.statusBarOrder && this.statusBarSorter) {
+            this.setElementIDs(this.statusBarSorter.el, {
+              useClass: true,
+              useIcon: true,
+            });
+            this.statusBarSorter.sort(this.settings.statusBarOrder);
+          }
+        }, 0);
+      })
+    );
+  }
 
-	registerMonkeyPatches() {
-		const plugin = this;
-		this.register(
-			around(this.app.viewRegistry.constructor.prototype, {
-				registerView(old: any) {
-					return function (
-						type: string,
-						viewCreator: ViewCreator,
-						...args: unknown[]
-					) {
-						plugin.app.workspace.trigger("view-registered", type, viewCreator);
-						return old.call(this, type, viewCreator, ...args);
-					};
-				},
-			}),
-		);
-		// This catches the initial FE view registration so that we can patch the sort button creation logic before
-		// the button is created
-		// TODO: Add conditional logic to patch the sort button even if we don't catch the initial startup
-		// 1) If layout ready, get the existing FE instance, create a patched button, and hide the existing button
-		// 2) Patch `addSortButton` to emit an event
-		// 3) On event,
-		if (!this.app.workspace.layoutReady) {
-			let eventRef = this.app.workspace.on(
-				"view-registered",
-				(type: string, viewCreator: ViewCreator) => {
-					if (type !== "file-explorer") return;
-					this.app.workspace.offref(eventRef);
-					// @ts-ignore we need a leaf before any leafs exists in the workspace, so we create one from scratch
-					let leaf = new WorkspaceLeaf(plugin.app);
-					let fileExplorer = viewCreator(leaf) as FileExplorerView;
-					this.patchFileExplorer(fileExplorer);
-				},
-			);
-		} else {
-			let fileExplorer = this.getFileExplorer();
-			this.patchFileExplorer(fileExplorer);
-		}
-		this.register(
-			around(View.prototype, {
-				onunload(old: any) {
-					return function (...args) {
-						try {
-							if (this.iconSorter) {
-								this.iconSorter.destroy();
-								this.iconSorter = null;
-							}
-						} catch {}
-						return old.call(this, ...args);
-					};
-				},
-				onload(old: any) {
-					return function (...args) {
-						setTimeout(() => {
-							if (this.app.workspace.layoutReady) {
-								try {
-									if (!(this.leaf.parentSplit instanceof WorkspaceTabs)) {
-										if (this.hasOwnProperty("actionsEl") && !this.iconSorter) {
-											this.iconSorter = plugin.setViewActionSorter(
-												this.actionsEl,
-												this,
-											);
-										}
-									}
-								} catch {}
-							}
-						}, 200);
+  registerMonkeyPatches() {
+    const plugin = this;
+    this.register(
+      around(this.app.viewRegistry.constructor.prototype, {
+        registerView(old: any) {
+          return function (
+            type: string,
+            viewCreator: ViewCreator,
+            ...args: unknown[]
+          ) {
+            plugin.app.workspace.trigger("view-registered", type, viewCreator);
+            return old.call(this, type, viewCreator, ...args);
+          };
+        },
+      })
+    );
+    // This catches the initial FE view registration so that we can patch the sort button creation logic before
+    // the button is created
+    // TODO: Add conditional logic to patch the sort button even if we don't catch the initial startup
+    // 1) If layout ready, get the existing FE instance, create a patched button, and hide the existing button
+    // 2) Patch `addSortButton` to emit an event
+    // 3) On event,
+    if (this.app.workspace.layoutReady) {
+      const fileExplorer = this.getFileExplorer();
+      this.patchFileExplorer(fileExplorer);
+    } else {
+      const eventRef = this.app.workspace.on(
+        "view-registered",
+        (type: string, viewCreator: ViewCreator) => {
+          if (type !== "file-explorer") return;
+          this.app.workspace.offref(eventRef);
+          // @ts-ignore we need a leaf before any leafs exists in the workspace, so we create one from scratch
+          const leaf = new WorkspaceLeaf(plugin.app);
+          const fileExplorer = viewCreator(leaf) as FileExplorerView;
+          this.patchFileExplorer(fileExplorer);
+        }
+      );
+    }
+    this.register(
+      around(View.prototype, {
+        onunload(old: any) {
+          return function (...args) {
+            try {
+              if (this.iconSorter) {
+                this.iconSorter.destroy();
+                this.iconSorter = null;
+              }
+            } catch {}
+            return old.call(this, ...args);
+          };
+        },
+        onload(old: any) {
+          return function (...args) {
+            setTimeout(() => {
+              if (this.app.workspace.layoutReady) {
+                try {
+                  if (
+                    !(this.leaf.parentSplit instanceof WorkspaceTabs) &&
+                    this.hasOwnProperty("actionsEl") &&
+                    !this.iconSorter
+                  ) {
+                    this.iconSorter = plugin.setViewActionSorter(
+                      this.actionsEl,
+                      this
+                    );
+                  }
+                } catch {}
+              }
+            }, 200);
 
-						return old.call(this, ...args);
-					};
-				},
-			}),
-		);
-		if (Platform.isDesktop) {
-			this.register(
-				around(HTMLDivElement.prototype, {
-					addEventListener(old: any) {
-						return function (
-							type: string,
-							listener: EventListenerOrEventListenerObject,
-							options?: boolean | AddEventListenerOptions,
-						) {
-							if (
-								type === "mousedown" &&
-								listener instanceof Function &&
-								this.hasClass("workspace-tab-header")
-							) {
-								let origListener = listener;
-								listener = (event) => {
-									if (
-										event instanceof MouseEvent &&
-										(event?.altKey || event?.metaKey)
-									)
-										return;
-									else origListener(event);
-								};
-							}
-							const result = old.call(this, type, listener, options);
-							return result;
-						};
-					},
-				}),
-			);
-		}
-		this.register(
-			around(Workspace.prototype, {
-				splitLeaf(old: any) {
-					return function (
-						source: WorkspaceItem,
-						newLeaf: WorkspaceItem,
-						direction?: SplitDirection,
-						before?: boolean,
-						...args
-					) {
-						let result = old.call(
-							this,
-							source,
-							newLeaf,
-							direction,
-							before,
-							...args,
-						);
-						this.trigger("bartender-leaf-split", source, newLeaf);
-						return result;
-					};
-				},
-				changeLayout(old: any) {
-					return async function (workspace: any, ...args): Promise<void> {
-						let result = await old.call(this, workspace, ...args);
-						this.trigger("bartender-workspace-change");
-						return result;
-					};
-				},
-			}),
-		);
-		this.register(
-			around(Plugin.prototype, {
-				addStatusBarItem(old: any) {
-					return function (...args): HTMLElement {
-						const result = old.call(this, ...args);
-						this.app.workspace.trigger("status-bar-updated");
-						return result;
-					};
-				},
-				addRibbonIcon(old: any) {
-					return function (...args): HTMLElement {
-						const result = old.call(this, ...args);
-						this.app.workspace.trigger("ribbon-bar-updated");
-						return result;
-					};
-				},
-			}),
-		);
-	}
+            return old.call(this, ...args);
+          };
+        },
+      })
+    );
+    if (Platform.isDesktop) {
+      this.register(
+        around(HTMLDivElement.prototype, {
+          addEventListener(old: any) {
+            return function (
+              type: string,
+              listener: EventListenerOrEventListenerObject,
+              options?: boolean | AddEventListenerOptions
+            ) {
+              if (
+                type === "mousedown" &&
+                listener instanceof Function &&
+                this.hasClass("workspace-tab-header")
+              ) {
+                const origListener = listener;
+                listener = (event) => {
+                  if (
+                    event instanceof MouseEvent &&
+                    (event?.altKey || event?.metaKey)
+                  )
+                    return;
+                  else origListener(event);
+                };
+              }
+              return old.call(this, type, listener, options);
+            };
+          },
+        })
+      );
+    }
+    this.register(
+      around(Workspace.prototype, {
+        splitLeaf(old: any) {
+          return function (
+            source: WorkspaceItem,
+            newLeaf: WorkspaceItem,
+            direction?: SplitDirection,
+            before?: boolean,
+            ...args
+          ) {
+            const result = old.call(
+              this,
+              source,
+              newLeaf,
+              direction,
+              before,
+              ...args
+            );
+            this.trigger("bartender-leaf-split", source, newLeaf);
+            return result;
+          };
+        },
+        changeLayout(old: any) {
+          return async function (workspace: any, ...args): Promise<void> {
+            const result = await old.call(this, workspace, ...args);
+            this.trigger("bartender-workspace-change");
+            return result;
+          };
+        },
+      })
+    );
+    this.register(
+      around(Plugin.prototype, {
+        addStatusBarItem(old: any) {
+          return function (...args): HTMLElement {
+            const result = old.call(this, ...args);
+            this.app.workspace.trigger("status-bar-updated");
+            return result;
+          };
+        },
+        addRibbonIcon(old: any) {
+          return function (...args): HTMLElement {
+            const result = old.call(this, ...args);
+            this.app.workspace.trigger("ribbon-bar-updated");
+            return result;
+          };
+        },
+      })
+    );
+  }
 
-	patchFileExplorer(fileExplorer: FileExplorerView) {
-		let plugin = this;
-		let settings = this.settings;
-		if (fileExplorer) {
-			let InfinityScroll = fileExplorer.tree.infinityScroll.constructor;
-			// register clear first so that it gets called first onunload
-			this.register(() => this.clearFileExplorerFilter());
-			this.register(
-				around(InfinityScroll.prototype, {
-					compute(old: any) {
-						return function (...args: any[]) {
-							try {
-								if (this.scrollEl.hasClass("nav-files-container")) {
-									plugin.fileExplorerFilter.call(this, fileExplorer);
-								}
-							} catch (err) {
-								console.log(err);
-							}
-							const result = old.call(this, ...args);
-							return result;
-						};
-					},
-				}),
-			);
-			this.register(
-				around(fileExplorer.headerDom.constructor.prototype, {
-					addSortButton(old: any) {
-						return function (...args: any[]) {
-							if (
-								this.navHeaderEl?.parentElement?.dataset?.type ===
-								"file-explorer"
-							) {
-								plugin.setFileExplorerFilter(this);
-								return addSortButton.call(this, settings, ...args);
-							} else {
-								return old.call(this, ...args);
-							}
-						};
-					},
-				}),
-			);
-		}
-	}
+  patchFileExplorer(fileExplorer: FileExplorerView) {
+    const plugin = this;
+    const settings = this.settings;
+    if (!fileExplorer) {
+      return;
+    }
+    const InfinityScroll = fileExplorer.tree.infinityScroll.constructor;
+    // register clear first so that it gets called first onunload
+    this.register(() => this.clearFileExplorerFilter());
+    this.register(
+      around(InfinityScroll.prototype, {
+        compute(old: any) {
+          return function (...args: any[]) {
+            try {
+              if (this.scrollEl.hasClass("nav-files-container")) {
+                plugin.fileExplorerFilter.call(this, fileExplorer);
+              }
+            } catch (err) {
+              console.log(err);
+            }
+            const result = old.call(this, ...args);
+            return result;
+          };
+        },
+      })
+    );
+    this.register(
+      around(fileExplorer.headerDom.constructor.prototype, {
+        addSortButton(old: any) {
+          return function (...args: any[]) {
+            if (
+              this.navHeaderEl?.parentElement?.dataset?.type === "file-explorer"
+            ) {
+              plugin.setFileExplorerFilter(this);
+              return addSortButton.call(this, settings, ...args);
+            } else {
+              return old.call(this, ...args);
+            }
+          };
+        },
+      })
+    );
+  }
 
-	insertSeparator(
-		selector: string,
-		className: string,
-		rtl: Boolean,
-		glyphSize: number = 16,
-	) {
-		let elements = document.body.querySelectorAll(selector);
-		elements.forEach((el: HTMLElement) => {
-			let getSiblings = rtl ? getPreviousSiblings : getNextSiblings;
-			if (el) {
-				let separator = el.createDiv(`${className} separator`);
-				rtl && el.prepend(separator);
-				let glyphEl = separator.createDiv("glyph");
-				let glyphName = "plus-with-circle"; // this gets replaced using CSS
-				// TODO: Handle mobile icon size differences?
-				setIcon(glyphEl, glyphName, glyphSize);
-				separator.addClass("is-collapsed");
-				this.register(() => separator.detach());
-				let hideTimeout: NodeJS.Timeout;
-				separator.onClickEvent((event: MouseEvent) => {
-					if (separator.hasClass("is-collapsed")) {
-						Array.from(el.children).forEach((el) =>
-							el.removeClass("is-hidden"),
-						);
-						separator.removeClass("is-collapsed");
-					} else {
-						getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
-						separator.addClass("is-collapsed");
-					}
-				});
-				el.onmouseenter = (ev) => {
-					hideTimeout && clearTimeout(hideTimeout);
-				};
-				el.onmouseleave = (ev) => {
-					if (this.settings.autoHide) {
-						hideTimeout = setTimeout(() => {
-							getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
-							separator.addClass("is-collapsed");
-						}, this.settings.autoHideDelay);
-					}
-				};
-				setTimeout(() => {
-					getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
-					separator.addClass("is-collapsed");
-				}, 0);
-			}
-		});
-	}
+  insertSeparator(selector: string, className: string, rtl: Boolean) {
+    const elements = document.body.querySelectorAll(selector);
+    elements.forEach((el: HTMLElement) => {
+      const getSiblings = rtl ? getPreviousSiblings : getNextSiblings;
+      if (!el) {
+        return;
+      }
+      const separator = el.createDiv(`${className} separator`);
+      rtl && el.prepend(separator);
+      const glyphEl = separator.createDiv("glyph");
+      const glyphName = "plus-with-circle"; // this gets replaced using CSS
+      setIcon(glyphEl, glyphName);
+      separator.addClass("is-collapsed");
+      this.register(() => separator.detach());
+      let hideTimeout: NodeJS.Timeout;
+      separator.onClickEvent((event: MouseEvent) => {
+        if (separator.hasClass("is-collapsed")) {
+          Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+          separator.removeClass("is-collapsed");
+        } else {
+          getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
+          separator.addClass("is-collapsed");
+        }
+      });
+      el.onmouseenter = (ev) => {
+        if (hideTimeout) clearTimeout(hideTimeout);
+      };
+      el.onmouseleave = (ev) => {
+        if (this.settings.autoHide) {
+          hideTimeout = setTimeout(() => {
+            getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
+            separator.addClass("is-collapsed");
+          }, this.settings.autoHideDelay);
+        }
+      };
+      setTimeout(() => {
+        getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
+        separator.addClass("is-collapsed");
+      }, 0);
+    });
+  }
 
-	setElementIDs(parentEl: HTMLElement, options: GenerateIdOptions) {
-		Array.from(parentEl.children).forEach((child) => {
-			if (child instanceof HTMLElement) {
-				if (!child.getAttribute("data-id")) {
-					child.setAttribute("data-id", generateId(child, options));
-				}
-			}
-		});
-	}
+  setElementIDs(parentEl: HTMLElement, options: GenerateIdOptions) {
+    Array.from(parentEl.children).forEach((child) => {
+      if (child instanceof HTMLElement && !child.getAttribute("data-id")) {
+        child.setAttribute("data-id", generateId(child, options));
+      }
+    });
+  }
 
-	setTabBarSorter(element: HTMLElement, leaf: WorkspaceTabs) {
-		this.setElementIDs(element, { useClass: true, useIcon: true });
-		let sorter = Sortable.create(element, {
-			group: "leftTabBar",
-			dataIdAttr: "data-id",
-			chosenClass: "bt-sortable-chosen",
-			delay: Platform.isMobile ? 200 : this.settings.dragDelay,
-			dropBubble: false,
-			dragoverBubble: false,
-			animation: ANIMATION_DURATION,
-			onChoose: () => element.parentElement?.addClass("is-dragging"),
-			onUnchoose: () => element.parentElement?.removeClass("is-dragging"),
-			onStart: () => {
-				document.body.addClass("is-dragging");
-				element.querySelector(".separator")?.removeClass("is-collapsed");
-				Array.from(element.children).forEach((el) =>
-					el.removeClass("is-hidden"),
-				);
-			},
-			onEnd: (event) => {
-				document.body.removeClass("is-dragging");
-				if (event.oldIndex !== undefined && event.newIndex !== undefined) {
-					reorderArray(leaf.children, event.oldIndex, event.newIndex);
-					leaf.currentTab = event.newIndex;
-					leaf.recomputeChildrenDimensions();
-				}
-				this.app.workspace.requestSaveLayout();
-			},
-		});
-		return sorter;
-	}
+  setTabBarSorter(element: HTMLElement, leaf: WorkspaceTabs) {
+    this.setElementIDs(element, { useClass: true, useIcon: true });
+    return Sortable.create(element, {
+      group: "leftTabBar",
+      dataIdAttr: "data-id",
+      chosenClass: "bt-sortable-chosen",
+      delay: Platform.isMobile ? 200 : this.settings.dragDelay,
+      dropBubble: false,
+      dragoverBubble: false,
+      animation: ANIMATION_DURATION,
+      onChoose: () => element.parentElement?.addClass("is-dragging"),
+      onUnchoose: () => element.parentElement?.removeClass("is-dragging"),
+      onStart: () => {
+        document.body.addClass("is-dragging");
+        element.querySelector(".separator")?.removeClass("is-collapsed");
+        Array.from(element.children).forEach((el) =>
+          el.removeClass("is-hidden")
+        );
+      },
+      onEnd: (event) => {
+        document.body.removeClass("is-dragging");
+        if (event.oldIndex !== undefined && event.newIndex !== undefined) {
+          reorderArray(leaf.children, event.oldIndex, event.newIndex);
+          leaf.currentTab = event.newIndex;
+          leaf.recomputeChildrenDimensions();
+        }
+        this.app.workspace.requestSaveLayout();
+      },
+    });
+  }
 
-	setStatusBarSorter() {
-		let el = document.body.querySelector(
-			"body > div.app-container > div.status-bar",
-		) as HTMLElement;
-		if (el) {
-			this.setElementIDs(el, { useClass: true, useAria: true, useIcon: true });
-			this.statusBarSorter = Sortable.create(el, {
-				group: "statusBar",
-				dataIdAttr: "data-id",
-				chosenClass: "bt-sortable-chosen",
-				delay: Platform.isMobile ? 200 : this.settings.dragDelay,
-				animation: ANIMATION_DURATION,
-				onChoose: () => {
-					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-				},
-				onStart: () => {
-					el.querySelector(".separator")?.removeClass("is-collapsed");
-					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-				},
-				store: {
-					get: (sortable) => {
-						return this.settings.statusBarOrder;
-					},
-					set: (s) => {
-						this.settings.statusBarOrder = s.toArray();
-						this.saveSettings();
-					},
-				},
-			});
-		}
-	}
+  setStatusBarSorter() {
+    const el = document.body.querySelector(
+      "body > div.app-container > div.status-bar"
+    ) as HTMLElement;
+    if (el) {
+      this.setElementIDs(el, { useClass: true, useAria: true, useIcon: true });
+      this.statusBarSorter = Sortable.create(el, {
+        group: "statusBar",
+        dataIdAttr: "data-id",
+        chosenClass: "bt-sortable-chosen",
+        delay: Platform.isMobile ? 200 : this.settings.dragDelay,
+        animation: ANIMATION_DURATION,
+        onChoose: () => {
+          Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+        },
+        onStart: () => {
+          el.querySelector(".separator")?.removeClass("is-collapsed");
+          Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+        },
+        store: {
+          get: (sortable) => {
+            return this.settings.statusBarOrder;
+          },
+          set: (s) => {
+            this.settings.statusBarOrder = s.toArray();
+            this.saveSettings();
+          },
+        },
+      });
+    }
+  }
 
-	setViewActionSorter(el: HTMLElement, view: View): Sortable | undefined {
-		this.setElementIDs(el, { useClass: true, useIcon: true });
-		let hasSorter = Object.values(el).find((value) =>
-			value?.hasOwnProperty("nativeDraggable"),
-		);
-		if (hasSorter) return undefined;
-		let viewType = view?.getViewType() || "unknown";
-		let sortable = new Sortable(el, {
-			group: "actionBar",
-			dataIdAttr: "data-id",
-			chosenClass: "bt-sortable-chosen",
-			delay: Platform.isMobile ? 200 : this.settings.dragDelay,
-			sort: true,
-			animation: ANIMATION_DURATION,
-			onStart: () => {
-				el.querySelector(".separator")?.removeClass("is-collapsed");
-				Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-			},
-			store: {
-				get: () => {
-					return this.settings.actionBarOrder[viewType];
-				},
-				set: (s) => {
-					this.settings.actionBarOrder[viewType] = s.toArray();
-					this.saveSettings();
-				},
-			},
-		});
-		return sortable;
-	}
+  setViewActionSorter(el: HTMLElement, view: View): Sortable | undefined {
+    this.setElementIDs(el, { useClass: true, useIcon: true });
+    const hasSorter = Object.values(el).find((value) =>
+      value?.hasOwnProperty("nativeDraggable")
+    );
+    if (hasSorter) return undefined;
+    const viewType = view?.getViewType() || "unknown";
+    return new Sortable(el, {
+      group: "actionBar",
+      dataIdAttr: "data-id",
+      chosenClass: "bt-sortable-chosen",
+      delay: Platform.isMobile ? 200 : this.settings.dragDelay,
+      sort: true,
+      animation: ANIMATION_DURATION,
+      onStart: () => {
+        el.querySelector(".separator")?.removeClass("is-collapsed");
+        Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+      },
+      store: {
+        get: () => {
+          return this.settings.actionBarOrder[viewType];
+        },
+        set: (s) => {
+          this.settings.actionBarOrder[viewType] = s.toArray();
+          this.saveSettings();
+        },
+      },
+    });
+  }
 
-	setRibbonBarSorter() {
-		let el = document.body.querySelector(
-			"body > div.app-container div.side-dock-actions",
-		) as HTMLElement;
-		if (el) {
-			this.setElementIDs(el, { useClass: true, useAria: true, useIcon: true });
-			this.ribbonBarSorter = Sortable.create(el, {
-				group: "ribbonBar",
-				dataIdAttr: "data-id",
-				delay: Platform.isMobile ? 200 : this.settings.dragDelay,
-				chosenClass: "bt-sortable-chosen",
-				animation: ANIMATION_DURATION,
-				onChoose: () => {
-					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-				},
-				onStart: () => {
-					el.querySelector(".separator")?.removeClass("is-collapsed");
-					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-				},
-				store: {
-					get: (sortable) => {
-						return this.settings.ribbonBarOrder;
-					},
-					set: (s) => {
-						this.settings.ribbonBarOrder = s.toArray();
-						this.saveSettings();
-					},
-				},
-			});
-		}
-	}
+  setRibbonBarSorter() {
+    const el = document.body.querySelector(
+      "body > div.app-container div.side-dock-actions"
+    ) as HTMLElement;
+    if (el) {
+      this.setElementIDs(el, { useClass: true, useAria: true, useIcon: true });
+      this.ribbonBarSorter = Sortable.create(el, {
+        group: "ribbonBar",
+        dataIdAttr: "data-id",
+        delay: Platform.isMobile ? 200 : this.settings.dragDelay,
+        chosenClass: "bt-sortable-chosen",
+        animation: ANIMATION_DURATION,
+        onChoose: () => {
+          Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+        },
+        onStart: () => {
+          el.querySelector(".separator")?.removeClass("is-collapsed");
+          Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+        },
+        store: {
+          get: (sortable) => {
+            return this.settings.ribbonBarOrder;
+          },
+          set: (s) => {
+            this.settings.ribbonBarOrder = s.toArray();
+            this.saveSettings();
+          },
+        },
+      });
+    }
+  }
 
-	setFileExplorerFilter(headerDom: FileExplorerHeader) {
-		let fileExplorerNav = headerDom.navHeaderEl;
-		if (fileExplorerNav) {
-			let fileExplorerFilter = fileExplorerNav.createDiv(
-				"search-input-container",
-			);
-			fileExplorerNav.insertAdjacentElement("afterend", fileExplorerFilter);
-			let fileExplorerFilterInput = fileExplorerFilter.createEl("input");
-			fileExplorerFilterInput.placeholder = "Type to filter...";
-			fileExplorerFilterInput.type = "text";
-			fileExplorerFilter.hide();
-			let filterScope = new Scope(this.app.scope);
-			fileExplorerFilterInput.onfocus = () => {
-				this.app.keymap.pushScope(filterScope);
-			};
-			fileExplorerFilterInput.onblur = () => {
-				this.app.keymap.popScope(filterScope);
-			};
-			fileExplorerFilterInput.oninput = (ev: InputEvent) => {
-				let fileExplorer = this.getFileExplorer();
-				if (ev.target instanceof HTMLInputElement) {
-					if (ev.target.value.length) {
-						clearButtonEl.show();
-					} else {
-						clearButtonEl.hide();
-					}
-					fileExplorer.tree.infinityScroll.filter = ev.target.value;
-				}
-				fileExplorer.tree.infinityScroll.compute();
-			};
-			let clearButtonEl = fileExplorerFilter.createDiv(
-				"search-input-clear-button",
-				function (el) {
-					el.addEventListener("click", function () {
-						(fileExplorerFilterInput.value = ""), clearButtonEl.hide();
-						fileExplorerFilterInput.focus();
-						fileExplorerFilterInput.dispatchEvent(new Event("input"));
-					}),
-						el.hide();
-				},
-			);
-		}
-	}
+  setFileExplorerFilter(headerDom: FileExplorerHeader) {
+    const fileExplorerNav = headerDom.navHeaderEl;
+    if (!fileExplorerNav) {
+      return;
+    }
+    const fileExplorerFilter = fileExplorerNav.createDiv(
+      "search-input-container"
+    );
+    fileExplorerNav.insertAdjacentElement("afterend", fileExplorerFilter);
+    const fileExplorerFilterInput = fileExplorerFilter.createEl("input");
+    fileExplorerFilterInput.placeholder = "Type to filter...";
+    fileExplorerFilterInput.type = "text";
+    fileExplorerFilter.hide();
+    const filterScope = new Scope(this.app.scope);
+    fileExplorerFilterInput.onfocus = () => {
+      this.app.keymap.pushScope(filterScope);
+    };
+    fileExplorerFilterInput.onblur = () => {
+      this.app.keymap.popScope(filterScope);
+    };
+    fileExplorerFilterInput.oninput = (ev: InputEvent) => {
+      const fileExplorer = this.getFileExplorer();
+      if (ev.target instanceof HTMLInputElement) {
+        if (ev.target.value.length) {
+          clearButtonEl.show();
+        } else {
+          clearButtonEl.hide();
+        }
+        fileExplorer.tree.infinityScroll.filter = ev.target.value;
+      }
+      fileExplorer.tree.infinityScroll.compute();
+    };
+    const clearButtonEl = fileExplorerFilter.createDiv(
+      "search-input-clear-button",
+      (el) => {
+        el.addEventListener("click", function () {
+          (fileExplorerFilterInput.value = ""), clearButtonEl.hide();
+          fileExplorerFilterInput.focus();
+          fileExplorerFilterInput.dispatchEvent(new Event("input"));
+        }),
+          el.hide();
+      }
+    );
+  }
 
-	setFileExplorerSorter(fileExplorer?: FileExplorerView) {
-		// TODO: Register sorter on new folder creation
-		// TODO: Unregister sorter on folder deletion
-		if (!fileExplorer) fileExplorer = this.getFileExplorer();
-		if (
-			!fileExplorer ||
-			this.settings.sortOrder !== "custom" ||
-			fileExplorer.hasCustomSorter
-		)
-			return;
-		let roots = this.getRootFolders(fileExplorer);
-		if (!roots || !roots.length) return;
-		for (let root of roots) {
-			let el = root?.childrenEl;
-			if (!el) continue;
-			let draggedItems: HTMLElement[];
-			fileExplorer.hasCustomSorter = true;
-			let dragEnabled = document.body
-				.querySelector("div.nav-action-button.drag-to-rearrange")
-				?.hasClass("is-active")
-				? true
-				: false;
-			if (root.file?.path) {
-				root.sorter = Sortable.create(el!, {
-					group: "fileExplorer" + root.file.path,
-					forceFallback: true,
-					multiDrag: true,
-					// @ts-ignore
-					multiDragKey: "alt",
-					// selectedClass: "is-selected",
-					chosenClass: "bt-sortable-chosen",
-					delay: 0,
-					disabled: !dragEnabled,
-					sort: dragEnabled, // init with dragging disabled. the nav bar button will toggle on/off
-					animation: ANIMATION_DURATION,
-					onStart: (evt) => {
-						if (evt.items.length) {
-							draggedItems = evt.items;
-						} else {
-							draggedItems = [evt.item];
-						}
-					},
-					onMove: (evt) => {
-						// TODO: Refactor this
-						// Responsible for updating the internal Obsidian array that contains the file item order
-						// Without this logic, reordering is ephemeral and will be undone by Obisidian's native processes
-						const supportsVirtualChildren =
-							requireApiVersion && requireApiVersion("0.15.0");
-						let _children = supportsVirtualChildren
-							? root.vChildren?._children
-							: root.children;
-						if (!_children || !draggedItems?.length) return;
-						let children = _children.map((child) => child.el);
-						let adjacentEl = evt.related;
-						let targetIndex = children.indexOf(adjacentEl);
-						let firstItem = draggedItems.first();
-						let firstItemIndex = children.indexOf(firstItem!);
-						let _draggedItems = draggedItems.slice();
-						if (firstItemIndex > targetIndex) _draggedItems.reverse();
-						for (let item of _draggedItems) {
-							let itemIndex = children.indexOf(item);
-							_children = reorderArray(_children, itemIndex, targetIndex);
-							children = reorderArray(children, itemIndex, targetIndex);
-						}
-						this.settings.fileExplorerOrder[root.file.path] = _children.map(
-							(child) => child.file.path,
-						);
-						this.saveSettings();
-						// return !adjacentEl.hasClass("nav-folder");
-					},
-					onEnd: (evt) => {
-						draggedItems = [];
-						document.querySelector("body>div.drag-ghost")?.detach();
-					},
-				});
-			}
-		}
-	}
+  setFileExplorerSorter(fileExplorer?: FileExplorerView) {
+    // TODO: Register sorter on new folder creation
+    // TODO: Unregister sorter on folder deletion
+    if (!fileExplorer) fileExplorer = this.getFileExplorer();
+    if (
+      !fileExplorer ||
+      this.settings.sortOrder !== "custom" ||
+      fileExplorer.hasCustomSorter
+    )
+      return;
+    const roots = this.getRootFolders(fileExplorer);
+    if (!roots || !roots.length) return;
+    for (const root of roots) {
+      const el = root?.childrenEl;
+      if (!el) continue;
+      let draggedItems: HTMLElement[];
+      fileExplorer.hasCustomSorter = true;
+      const dragEnabled = document.body
+        .querySelector("div.nav-action-button.drag-to-rearrange")
+        ?.hasClass("is-active")
+        ? true
+        : false;
+      const path = root.file?.path ?? "root";
 
-	getFileExplorer() {
-		let fileExplorer: FileExplorerView | undefined = this.app.workspace
-			.getLeavesOfType("file-explorer")
-			?.first()?.view as unknown as FileExplorerView;
-		return fileExplorer;
-	}
+      console.log("Creating Sortable for", path);
+      root.sorter = Sortable.create(el!, {
+        group: `fileExplorer${path}`,
+        forceFallback: true,
+        multiDrag: true,
+        // @ts-ignore
+        multiDragKey: "alt",
+        // selectedClass: "is-selected",
+        chosenClass: "bt-sortable-chosen",
+        delay: 0,
+        disabled: !dragEnabled,
+        sort: dragEnabled, // init with dragging disabled. the nav bar button will toggle on/off
+        animation: ANIMATION_DURATION,
+        onStart: (evt) => {
+          console.log(evt);
+          draggedItems = evt.items.length ? evt.items : [evt.item];
+        },
+        onMove: (evt) => {
+          // TODO: Refactor this
+          // Responsible for updating the internal Obsidian array that contains the file item order
+          // Without this logic, reordering is ephemeral and will be undone by Obisidian's native processes
+          const supportsVirtualChildren = requireApiVersion?.("0.15.0");
+          let _children = supportsVirtualChildren
+            ? root.vChildren?._children
+            : root.children;
+          if (!_children || !draggedItems?.length) return;
+          let children = _children.map((child) => child.el);
+          const adjacentEl = evt.related;
+          const targetIndex = children.indexOf(adjacentEl);
+          const firstItem = draggedItems.first();
+          const firstItemIndex = children.indexOf(firstItem!);
+          const _draggedItems = draggedItems.slice();
+          if (firstItemIndex > targetIndex) _draggedItems.reverse();
+          for (const item of _draggedItems) {
+            const itemIndex = children.indexOf(item);
+            _children = reorderArray(_children, itemIndex, targetIndex);
+            children = reorderArray(children, itemIndex, targetIndex);
+          }
+          this.settings.fileExplorerOrder[path] = _children.map(
+            (child) => child.file.path
+          );
+          this.saveSettings();
+          // return !adjacentEl.hasClass("nav-folder");
+        },
+        onEnd: (_evt) => {
+          draggedItems = [];
+          document.querySelector("body>div.drag-ghost")?.detach();
+        },
+      });
+    }
+  }
 
-	getRootFolders(
-		fileExplorer?: FileExplorerView,
-	): [RootElements | ChildElement] | undefined {
-		if (!fileExplorer) fileExplorer = this.getFileExplorer();
-		if (!fileExplorer) return;
-		let root = fileExplorer.tree?.infinityScroll?.rootEl;
-		let roots = root && this.traverseRoots(root);
-		return roots;
-	}
+  getFileExplorer() {
+    const fileExplorer: FileExplorerView | undefined = this.app.workspace
+      .getLeavesOfType("file-explorer")
+      ?.first()?.view as unknown as FileExplorerView;
+    return fileExplorer;
+  }
 
-	traverseRoots(
-		root: RootElements | ChildElement,
-		items?: [RootElements | ChildElement],
-	) {
-		if (!items) items = [root];
-		const supportsVirtualChildren =
-			requireApiVersion && requireApiVersion("0.15.0");
-		const _children = supportsVirtualChildren
-			? root.vChildren?._children
-			: root.children;
-		for (let child of _children || []) {
-			if (child.children || child.vChildren?._children) {
-				items.push(child);
-			}
-			this.traverseRoots(child, items);
-		}
-		return items;
-	}
+  getRootFolders(
+    fileExplorer?: FileExplorerView
+  ): [RootElements | ChildElement] | undefined {
+    if (!fileExplorer) fileExplorer = this.getFileExplorer();
+    if (!fileExplorer) return;
+    const root = fileExplorer.tree?.infinityScroll?.rootEl;
+    return root && this.traverseRoots(root);
+  }
 
-	toggleFileExplorerSorters(enable: boolean) {
-		let fileExplorer = this.getFileExplorer();
-		let roots = this.getRootFolders(fileExplorer);
-		if (roots?.length) {
-			for (let root of roots) {
-				if (root.sorter) {
-					root.sorter.option("sort", enable);
-					root.sorter.option("disabled", !enable);
-				}
-			}
-		}
-	}
+  traverseRoots(
+    root: RootElements | ChildElement,
+    items?: [RootElements | ChildElement]
+  ) {
+    if (!items) items = [root];
+    const supportsVirtualChildren = requireApiVersion?.("0.15.0");
+    const _children = supportsVirtualChildren
+      ? root.vChildren?._children
+      : root.children;
+    for (const child of _children || []) {
+      if (child.children || child.vChildren?._children) {
+        items.push(child);
+      }
+      this.traverseRoots(child, items);
+    }
+    return items;
+  }
 
-	cleanupFileExplorerSorters() {
-		let fileExplorer = this.getFileExplorer();
-		let roots = this.getRootFolders(fileExplorer);
-		if (roots?.length) {
-			for (let root of roots) {
-				if (root.sorter) {
-					root.sorter.destroy();
-					delete root.sorter;
-					Object.keys(root.childrenEl!).forEach(
-						(key) =>
-							key.startsWith("Sortable") &&
-							delete (root.childrenEl as any)[key],
-					);
-					// sortable.destroy removes all of the draggble attributes :( so we put them back
-					root
-						.childrenEl!.querySelectorAll("div.nav-file-title")
-						.forEach((el: HTMLDivElement) => (el.draggable = true));
-					root
-						.childrenEl!.querySelectorAll("div.nav-folder-title")
-						.forEach((el: HTMLDivElement) => (el.draggable = true));
-				}
-			}
-		}
-		delete fileExplorer.hasCustomSorter;
-		// unset "custom" file explorer sort
-		if (this.app.vault.getConfig("fileSortOrder") === "custom") {
-			fileExplorer.setSortOrder("alphabetical");
-		}
-	}
+  toggleFileExplorerSorters(enable: boolean) {
+    const fileExplorer = this.getFileExplorer();
+    const roots = this.getRootFolders(fileExplorer);
+    if (roots?.length) {
+      for (const root of roots) {
+        if (root.sorter) {
+          root.sorter.option("sort", enable);
+          root.sorter.option("disabled", !enable);
+        }
+      }
+    }
+  }
 
-	onunload(): void {
-		this.statusBarSorter?.destroy();
-		this.ribbonBarSorter?.destroy();
-		this.app.workspace.iterateAllLeaves((leaf) => {
-			let sorterParent: View | WorkspaceTabs | WorkspaceLeaf | boolean;
-			if (
-				(sorterParent = leaf?.iconSorter ? leaf : false) ||
-				(sorterParent = leaf?.view?.iconSorter ? leaf.view : false) ||
-				(sorterParent =
-					leaf?.parentSplit instanceof WorkspaceTabs &&
-					leaf?.parentSplit?.iconSorter
-						? leaf?.parentSplit
-						: false)
-			) {
-				try {
-					sorterParent.iconSorter?.destroy();
-				} catch (err) {
-				} finally {
-					delete sorterParent.iconSorter;
-				}
-			}
-		});
+  cleanupFileExplorerSorters() {
+    const fileExplorer = this.getFileExplorer();
+    const roots = this.getRootFolders(fileExplorer);
+    if (roots?.length) {
+      for (const root of roots) {
+        if (root.sorter) {
+          root.sorter.destroy();
+          delete root.sorter;
+          Object.keys(root.childrenEl!).forEach(
+            (key) =>
+              key.startsWith("Sortable") && delete (root.childrenEl as any)[key]
+          );
+          // sortable.destroy removes all of the draggble attributes :( so we put them back
+          root
+            .childrenEl!.querySelectorAll("div.nav-file-title")
+            .forEach((el: HTMLDivElement) => (el.draggable = true));
+          root
+            .childrenEl!.querySelectorAll("div.nav-folder-title")
+            .forEach((el: HTMLDivElement) => (el.draggable = true));
+        }
+      }
+    }
+    delete fileExplorer.hasCustomSorter;
+    // unset "custom" file explorer sort
+    if (this.app.vault.getConfig("fileSortOrder") === "custom") {
+      fileExplorer.setSortOrder("alphabetical");
+    }
+  }
 
-		// clean up file explorer sorters
-		this.cleanupFileExplorerSorters();
-	}
+  onunload(): void {
+    this.statusBarSorter?.destroy();
+    this.ribbonBarSorter?.destroy();
+    this.app.workspace.iterateAllLeaves((leaf) => {
+      let sorterParent: View | WorkspaceTabs | WorkspaceLeaf | boolean;
+      if (
+        (sorterParent = leaf?.iconSorter ? leaf : false) ||
+        (sorterParent = leaf?.view?.iconSorter ? leaf.view : false) ||
+        (sorterParent =
+          leaf?.parentSplit instanceof WorkspaceTabs &&
+          leaf?.parentSplit?.iconSorter
+            ? leaf?.parentSplit
+            : false)
+      ) {
+        try {
+          sorterParent.iconSorter?.destroy();
+        } catch (err) {
+        } finally {
+          delete sorterParent.iconSorter;
+        }
+      }
+    });
+
+    // clean up file explorer sorters
+    this.cleanupFileExplorerSorters();
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,40 +1,44 @@
 import Fuse from "fuse.js";
 import { around } from "monkey-around";
 import {
-  ChildElement,
-  Component,
-  FileExplorerHeader,
-  FileExplorerView,
-  Platform,
-  Plugin,
-  RootElements,
-  Scope,
-  setIcon,
-  SplitDirection,
-  TFolder,
-  Vault,
-  View,
-  ViewCreator,
-  Workspace,
-  WorkspaceItem,
-  WorkspaceLeaf,
-  WorkspaceSplit,
-  WorkspaceTabs,
-  requireApiVersion,
+	ChildElement,
+	Component,
+	FileExplorerHeader,
+	FileExplorerView,
+	Platform,
+	Plugin,
+	RootElements,
+	Scope,
+	setIcon,
+	SplitDirection,
+	TFolder,
+	Vault,
+	View,
+	ViewCreator,
+	Workspace,
+	WorkspaceItem,
+	WorkspaceLeaf,
+	WorkspaceSplit,
+	WorkspaceTabs,
+	requireApiVersion,
 } from "obsidian";
 
 import Sortable, { MultiDrag } from "sortablejs";
 import { addSortButton, folderSort } from "./file-explorer/custom-sort";
-import { BartenderSettings, DEFAULT_SETTINGS, SettingTab } from "./settings/settings";
 import {
-  generateId,
-  GenerateIdOptions,
-  getFn,
-  getItems,
-  getNextSiblings,
-  getPreviousSiblings,
-  highlight,
-  reorderArray,
+	BartenderSettings,
+	DEFAULT_SETTINGS,
+	SettingTab,
+} from "./settings/settings";
+import {
+	generateId,
+	GenerateIdOptions,
+	getFn,
+	getItems,
+	getNextSiblings,
+	getPreviousSiblings,
+	highlight,
+	reorderArray,
 } from "./utils";
 
 Sortable.mount(new MultiDrag());
@@ -45,759 +49,877 @@ const DRAG_DELAY = Platform.isMobile ? 200 : 200;
 const ANIMATION_DURATION = 500;
 
 export default class BartenderPlugin extends Plugin {
-  statusBarSorter: Sortable;
-  ribbonBarSorter: Sortable;
-  fileSorter: Sortable;
-  separator: HTMLElement;
-  settings: BartenderSettings;
-  settingsTab: SettingTab;
+	statusBarSorter: Sortable;
+	ribbonBarSorter: Sortable;
+	fileSorter: Sortable;
+	separator: HTMLElement;
+	settings: BartenderSettings;
+	settingsTab: SettingTab;
 
-  async onload() {
-    await this.loadSettings();
-    this.registerMonkeyPatches();
-    this.registerEventHandlers();
-    this.registerSettingsTab();
-    this.initialize();
-  }
+	async onload() {
+		await this.loadSettings();
+		this.registerMonkeyPatches();
+		this.registerEventHandlers();
+		this.registerSettingsTab();
+		this.initialize();
+	}
 
-  async loadSettings() {
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-  }
+	async loadSettings() {
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+	}
 
-  async saveSettings() {
-    await this.saveData(this.settings);
-  }
+	async saveSettings() {
+		await this.saveData(this.settings);
+	}
 
-  patchFileExplorerFolder() {
-    let plugin = this;
-    let leaf = plugin.app.workspace.getLeaf(true);
-    let fileExplorer = plugin.app.viewRegistry.viewByType["file-explorer"](leaf) as FileExplorerView;
-    // @ts-ignore
-    let tmpFolder = new TFolder(Vault, "");
-    let Folder = fileExplorer.createFolderDom(tmpFolder).constructor;
-    this.register(
-      around(Folder.prototype, {
-        sort(old: any) {
-          return function (...args: any[]) {
-            let order = plugin.settings.fileExplorerOrder[this.file.path];
-            if (plugin.settings.sortOrder === "custom") {
-              return folderSort.call(this, order, ...args);
-            } else {
-              return old.call(this, ...args);
-            }
-          };
-        },
-      })
-    );
-    leaf.detach();
-  }
+	patchFileExplorerFolder() {
+		let plugin = this;
+		let leaf = plugin.app.workspace.getLeaf(true);
+		let fileExplorer = plugin.app.viewRegistry.viewByType["file-explorer"](
+			leaf,
+		) as FileExplorerView;
+		// @ts-ignore
+		let tmpFolder = new TFolder(Vault, "");
+		let Folder = fileExplorer.createFolderDom(tmpFolder).constructor;
+		this.register(
+			around(Folder.prototype, {
+				sort(old: any) {
+					return function (...args: any[]) {
+						let order = plugin.settings.fileExplorerOrder[this.file.path];
+						if (plugin.settings.sortOrder === "custom") {
+							return folderSort.call(this, order, ...args);
+						} else {
+							return old.call(this, ...args);
+						}
+					};
+				},
+			}),
+		);
+		leaf.detach();
+	}
 
-  initialize() {
-    this.app.workspace.onLayoutReady(() => {
-      this.patchFileExplorerFolder();
-      setTimeout(
-        () => {
-          if (Platform.isDesktop) {
-            // add sorter to the status bar
-            this.insertSeparator(STATUS_BAR_SELECTOR, "status-bar-item", true, 16);
-            this.setStatusBarSorter();
+	initialize() {
+		this.app.workspace.onLayoutReady(() => {
+			this.patchFileExplorerFolder();
+			setTimeout(
+				() => {
+					if (Platform.isDesktop) {
+						// add sorter to the status bar
+						this.insertSeparator(
+							STATUS_BAR_SELECTOR,
+							"status-bar-item",
+							true,
+							16,
+						);
+						this.setStatusBarSorter();
 
-            // add sorter to the sidebar tabs
-            if (requireApiVersion && !requireApiVersion("0.15.3")) {
-              let left = (this.app.workspace.leftSplit as WorkspaceSplit).children;
-              let right = (this.app.workspace.rightSplit as WorkspaceSplit).children;
-              left.concat(right).forEach(child => {
-                if (child.hasOwnProperty("tabsInnerEl") && !child.iconSorter) {
-                  child.iconSorter = this.setTabBarSorter(child.tabsInnerEl, child);
-                }
-              });
-            }
-          }
+						// add sorter to the sidebar tabs
+						if (requireApiVersion && !requireApiVersion("0.15.3")) {
+							let left = (this.app.workspace.leftSplit as WorkspaceSplit)
+								.children;
+							let right = (this.app.workspace.rightSplit as WorkspaceSplit)
+								.children;
+							left.concat(right).forEach((child) => {
+								if (child.hasOwnProperty("tabsInnerEl") && !child.iconSorter) {
+									child.iconSorter = this.setTabBarSorter(
+										child.tabsInnerEl,
+										child,
+									);
+								}
+							});
+						}
+					}
 
-          // add file explorer sorter
-          this.setFileExplorerSorter();
+					// add file explorer sorter
+					this.setFileExplorerSorter();
 
-          // add sorter to the left sidebar ribbon
-          this.insertSeparator(RIBBON_BAR_SELECTOR, "side-dock-ribbon-action", false, 18);
-          this.setRibbonBarSorter();
+					// add sorter to the left sidebar ribbon
+					this.insertSeparator(
+						RIBBON_BAR_SELECTOR,
+						"side-dock-ribbon-action",
+						false,
+						18,
+					);
+					this.setRibbonBarSorter();
 
-          // add sorter to all view actions icon groups
-          this.app.workspace.iterateRootLeaves(leaf => {
-            if (leaf?.view?.hasOwnProperty("actionsEl") && !leaf?.view?.hasOwnProperty("iconSorter")) {
-              leaf.view.iconSorter = this.setViewActionSorter(leaf.view.actionsEl, leaf.view);
-            }
-          });
-        },
-        Platform.isMobile ? 3000 : 400
-      ); // give time for plugins like Customizable Page Header to add their icons
-    });
-  }
+					// add sorter to all view actions icon groups
+					this.app.workspace.iterateRootLeaves((leaf) => {
+						if (
+							leaf?.view?.hasOwnProperty("actionsEl") &&
+							!leaf?.view?.hasOwnProperty("iconSorter")
+						) {
+							leaf.view.iconSorter = this.setViewActionSorter(
+								leaf.view.actionsEl,
+								leaf.view,
+							);
+						}
+					});
+				},
+				Platform.isMobile ? 3000 : 400,
+			); // give time for plugins like Customizable Page Header to add their icons
+		});
+	}
 
-  registerSettingsTab() {
-    this.settingsTab = new SettingTab(this.app, this);
-    this.addSettingTab(this.settingsTab);
-  }
+	registerSettingsTab() {
+		this.settingsTab = new SettingTab(this.app, this);
+		this.addSettingTab(this.settingsTab);
+	}
 
-  clearFileExplorerFilter() {
-    const fileExplorer = this.getFileExplorer();
-    let fileExplorerFilterEl: HTMLInputElement | null = document.body.querySelector(
-      '.workspace-leaf-content[data-type="file-explorer"] .search-input-container > input'
-    );
-    fileExplorerFilterEl && (fileExplorerFilterEl.value = "");
-    fileExplorer.tree.infinityScroll.filter = "";
-    fileExplorer.tree.infinityScroll.compute();
-  }
+	clearFileExplorerFilter() {
+		const fileExplorer = this.getFileExplorer();
+		let fileExplorerFilterEl: HTMLInputElement | null =
+			document.body.querySelector(
+				'.workspace-leaf-content[data-type="file-explorer"] .search-input-container > input',
+			);
+		fileExplorerFilterEl && (fileExplorerFilterEl.value = "");
+		fileExplorer.tree.infinityScroll.filter = "";
+		fileExplorer.tree.infinityScroll.compute();
+	}
 
-  fileExplorerFilter = function (fileExplorer:FileExplorerView) {
-
-    const supportsVirtualChildren = requireApiVersion && requireApiVersion("0.15.0");
-/*    let leaf = this?.rootEl?.view?.app.workspace.getLeaf(true);
+	fileExplorerFilter = function (fileExplorer: FileExplorerView) {
+		const supportsVirtualChildren =
+			requireApiVersion && requireApiVersion("0.15.0");
+		/*    let leaf = this?.rootEl?.view?.app.workspace.getLeaf(true);
     let fileExplorer = this?.rootEl?.view?.app.viewRegistry.viewByType["file-explorer"](leaf) as FileExplorerView;*/
 
-    //let fileExplorer = this?.rootEl?.fileExplorer;
+		//let fileExplorer = this?.rootEl?.fileExplorer;
 
-    if (!fileExplorer) return;
-    const _children = supportsVirtualChildren ? this.rootEl?.vChildren._children : this.rootEl?.children;
-    if (!_children) return;
-    if (this.filter?.length >= 1) {
-      if (!this.filtered) {
-        this.rootEl._children = _children;
-        this.filtered = true;
-      }
-      const options = {
-        includeScore: true,
-        includeMatches: true,
-        useExtendedSearch: true,
-        getFn: getFn,
-        threshold: 0.1,
-        ignoreLocation: true,
-        keys: ["file.path"],
-      };
-      let flattenedItems = getItems(this.rootEl._children);
-      const fuse = new Fuse(flattenedItems, options);
-      const maxResults = 200;
-      let results = fuse.search(this.filter).slice(0, maxResults);
-      if (supportsVirtualChildren) {
-        this.rootEl.vChildren._children = highlight(results);
-      } else {
-        this.rootEl.children = highlight(results);
-      }
-    } else if (this.filter?.length < 1 && this.filtered) {
-      if (this.rootEl._children) {
-        if (supportsVirtualChildren) {
-          this.rootEl.vChildren._children = this.rootEl._children;
-        } else {
-          this.rootEl.children = this.rootEl._children;
-        }
-      }
+		if (!fileExplorer) return;
+		const _children = supportsVirtualChildren
+			? this.rootEl?.vChildren._children
+			: this.rootEl?.children;
+		if (!_children) return;
+		if (this.filter?.length >= 1) {
+			if (!this.filtered) {
+				this.rootEl._children = _children;
+				this.filtered = true;
+			}
+			const options = {
+				includeScore: true,
+				includeMatches: true,
+				useExtendedSearch: true,
+				getFn: getFn,
+				threshold: 0.1,
+				ignoreLocation: true,
+				keys: ["file.path"],
+			};
+			let flattenedItems = getItems(this.rootEl._children);
+			const fuse = new Fuse(flattenedItems, options);
+			const maxResults = 200;
+			let results = fuse.search(this.filter).slice(0, maxResults);
+			if (supportsVirtualChildren) {
+				this.rootEl.vChildren._children = highlight(results);
+			} else {
+				this.rootEl.children = highlight(results);
+			}
+		} else if (this.filter?.length < 1 && this.filtered) {
+			if (this.rootEl._children) {
+				if (supportsVirtualChildren) {
+					this.rootEl.vChildren._children = this.rootEl._children;
+				} else {
+					this.rootEl.children = this.rootEl._children;
+				}
+			}
 
-      let flattenedItems = getItems(this.rootEl._children);
-      flattenedItems.map((match: ChildElement) => {
-        if ((<any>match).innerEl.origContent) {
-          match.innerEl.setText((<any>match).innerEl.origContent);
-          delete (<any>match).innerEl.origContent;
-          match.innerEl.removeClass("has-matches");
-        }
-      });
+			let flattenedItems = getItems(this.rootEl._children);
+			flattenedItems.map((match: ChildElement) => {
+				if ((<any>match).innerEl.origContent) {
+					match.innerEl.setText((<any>match).innerEl.origContent);
+					delete (<any>match).innerEl.origContent;
+					match.innerEl.removeClass("has-matches");
+				}
+			});
 
-      this.filtered = false;
-    }
-  };
+			this.filtered = false;
+		}
+	};
 
-  registerEventHandlers() {
-    this.registerEvent(
-      this.app.workspace.on("file-explorer-draggable-change", value => {
-        this.toggleFileExplorerSorters(value);
-      })
-    );
-    this.registerEvent(
-      this.app.workspace.on("file-explorer-sort-change", (sortMethod: string) => {
-        this.settings.sortOrder = sortMethod
-        this.saveSettings();
-        if (sortMethod === "custom") {
-          setTimeout(() => {
-            this.setFileExplorerSorter();
-          }, 10);
-        } else {
-          this.cleanupFileExplorerSorters();
-        }
-      })
-    );
-    this.registerEvent(
-      this.app.workspace.on("file-explorer-load", (fileExplorer: FileExplorerView) => {
-        setTimeout(() => {
-          this.setFileExplorerSorter(fileExplorer);
-        }, 1000);
-      })
-    );
-    this.registerEvent(
-      this.app.workspace.on("bartender-leaf-split", (originLeaf: WorkspaceItem, newLeaf: WorkspaceItem) => {
-        let element: HTMLElement = newLeaf.tabsInnerEl as HTMLElement;
-        if (newLeaf.type === "tabs" && newLeaf instanceof WorkspaceTabs) {
-          if (requireApiVersion && !requireApiVersion("0.15.3")) {
-            this.setTabBarSorter(element, newLeaf);
-          }
-        }
-      })
-    );
+	registerEventHandlers() {
+		this.registerEvent(
+			this.app.workspace.on("file-explorer-draggable-change", (value) => {
+				this.toggleFileExplorerSorters(value);
+			}),
+		);
+		this.registerEvent(
+			this.app.workspace.on(
+				"file-explorer-sort-change",
+				(sortMethod: string) => {
+					this.settings.sortOrder = sortMethod;
+					this.saveSettings();
+					if (sortMethod === "custom") {
+						setTimeout(() => {
+							this.setFileExplorerSorter();
+						}, 10);
+					} else {
+						this.cleanupFileExplorerSorters();
+					}
+				},
+			),
+		);
+		this.registerEvent(
+			this.app.workspace.on(
+				"file-explorer-load",
+				(fileExplorer: FileExplorerView) => {
+					setTimeout(() => {
+						this.setFileExplorerSorter(fileExplorer);
+					}, 1000);
+				},
+			),
+		);
+		this.registerEvent(
+			this.app.workspace.on(
+				"bartender-leaf-split",
+				(originLeaf: WorkspaceItem, newLeaf: WorkspaceItem) => {
+					let element: HTMLElement = newLeaf.tabsInnerEl as HTMLElement;
+					if (newLeaf.type === "tabs" && newLeaf instanceof WorkspaceTabs) {
+						if (requireApiVersion && !requireApiVersion("0.15.3")) {
+							this.setTabBarSorter(element, newLeaf);
+						}
+					}
+				},
+			),
+		);
 
-    this.registerEvent(
-      this.app.workspace.on("ribbon-bar-updated", () => {
-        setTimeout(() => {
-          if (this.settings.ribbonBarOrder && this.ribbonBarSorter) {
-            this.setElementIDs(this.ribbonBarSorter.el, { useClass: true, useAria: true, useIcon: true });
-            this.ribbonBarSorter.sort(this.settings.ribbonBarOrder);
-          }
-        }, 0);
-      })
-    );
-    this.registerEvent(
-      this.app.workspace.on("status-bar-updated", () => {
-        setTimeout(() => {
-          if (this.settings.statusBarOrder && this.statusBarSorter) {
-            this.setElementIDs(this.statusBarSorter.el, { useClass: true, useIcon: true });
-            this.statusBarSorter.sort(this.settings.statusBarOrder);
-          }
-        }, 0);
-      })
-    );
-  }
+		this.registerEvent(
+			this.app.workspace.on("ribbon-bar-updated", () => {
+				setTimeout(() => {
+					if (this.settings.ribbonBarOrder && this.ribbonBarSorter) {
+						this.setElementIDs(this.ribbonBarSorter.el, {
+							useClass: true,
+							useAria: true,
+							useIcon: true,
+						});
+						this.ribbonBarSorter.sort(this.settings.ribbonBarOrder);
+					}
+				}, 0);
+			}),
+		);
+		this.registerEvent(
+			this.app.workspace.on("status-bar-updated", () => {
+				setTimeout(() => {
+					if (this.settings.statusBarOrder && this.statusBarSorter) {
+						this.setElementIDs(this.statusBarSorter.el, {
+							useClass: true,
+							useIcon: true,
+						});
+						this.statusBarSorter.sort(this.settings.statusBarOrder);
+					}
+				}, 0);
+			}),
+		);
+	}
 
-  registerMonkeyPatches() {
-    const plugin = this;
-    this.register(
-      around(this.app.viewRegistry.constructor.prototype, {
-        registerView(old: any) {
-          return function (type: string, viewCreator: ViewCreator, ...args: unknown[]) {
-            plugin.app.workspace.trigger("view-registered", type, viewCreator);
-            return old.call(this, type, viewCreator, ...args);
-          };
-        },
-      })
-    );
-    // This catches the initial FE view registration so that we can patch the sort button creation logic before
-    // the button is created
-    // TODO: Add conditional logic to patch the sort button even if we don't catch the initial startup
-    // 1) If layout ready, get the existing FE instance, create a patched button, and hide the existing button
-    // 2) Patch `addSortButton` to emit an event
-    // 3) On event,
-    if (!this.app.workspace.layoutReady) {
-      let eventRef = this.app.workspace.on("view-registered", (type: string, viewCreator: ViewCreator) => {
-        if (type !== "file-explorer") return;
-        this.app.workspace.offref(eventRef);
-        // @ts-ignore we need a leaf before any leafs exists in the workspace, so we create one from scratch
-        let leaf = new WorkspaceLeaf(plugin.app);
-        let fileExplorer = viewCreator(leaf) as FileExplorerView;
-        this.patchFileExplorer(fileExplorer);
-      });
-    } else {
-      let fileExplorer = this.getFileExplorer();
-      this.patchFileExplorer(fileExplorer);
-    }
-    this.register(
-      around(View.prototype, {
-        onunload(old: any) {
-          return function (...args) {
-            try {
-              if (this.iconSorter) {
-                this.iconSorter.destroy();
-                this.iconSorter = null;
-              }
-            } catch {}
-            return old.call(this, ...args);
-          };
-        },
-        onload(old: any) {
-          return function (...args) {
-            setTimeout(() => {
-              if (this.app.workspace.layoutReady) {
-                try {
-                  if (!(this.leaf.parentSplit instanceof WorkspaceTabs)) {
-                    if (this.hasOwnProperty("actionsEl") && !this.iconSorter) {
-                      this.iconSorter = plugin.setViewActionSorter(this.actionsEl, this);
-                    }
-                  }
-                } catch {}
-              }
-            }, 200);
+	registerMonkeyPatches() {
+		const plugin = this;
+		this.register(
+			around(this.app.viewRegistry.constructor.prototype, {
+				registerView(old: any) {
+					return function (
+						type: string,
+						viewCreator: ViewCreator,
+						...args: unknown[]
+					) {
+						plugin.app.workspace.trigger("view-registered", type, viewCreator);
+						return old.call(this, type, viewCreator, ...args);
+					};
+				},
+			}),
+		);
+		// This catches the initial FE view registration so that we can patch the sort button creation logic before
+		// the button is created
+		// TODO: Add conditional logic to patch the sort button even if we don't catch the initial startup
+		// 1) If layout ready, get the existing FE instance, create a patched button, and hide the existing button
+		// 2) Patch `addSortButton` to emit an event
+		// 3) On event,
+		if (!this.app.workspace.layoutReady) {
+			let eventRef = this.app.workspace.on(
+				"view-registered",
+				(type: string, viewCreator: ViewCreator) => {
+					if (type !== "file-explorer") return;
+					this.app.workspace.offref(eventRef);
+					// @ts-ignore we need a leaf before any leafs exists in the workspace, so we create one from scratch
+					let leaf = new WorkspaceLeaf(plugin.app);
+					let fileExplorer = viewCreator(leaf) as FileExplorerView;
+					this.patchFileExplorer(fileExplorer);
+				},
+			);
+		} else {
+			let fileExplorer = this.getFileExplorer();
+			this.patchFileExplorer(fileExplorer);
+		}
+		this.register(
+			around(View.prototype, {
+				onunload(old: any) {
+					return function (...args) {
+						try {
+							if (this.iconSorter) {
+								this.iconSorter.destroy();
+								this.iconSorter = null;
+							}
+						} catch {}
+						return old.call(this, ...args);
+					};
+				},
+				onload(old: any) {
+					return function (...args) {
+						setTimeout(() => {
+							if (this.app.workspace.layoutReady) {
+								try {
+									if (!(this.leaf.parentSplit instanceof WorkspaceTabs)) {
+										if (this.hasOwnProperty("actionsEl") && !this.iconSorter) {
+											this.iconSorter = plugin.setViewActionSorter(
+												this.actionsEl,
+												this,
+											);
+										}
+									}
+								} catch {}
+							}
+						}, 200);
 
-            return old.call(this, ...args);
-          };
-        },
-      })
-    );
-    if (Platform.isDesktop) {
-      this.register(
-        around(HTMLDivElement.prototype, {
-          addEventListener(old: any) {
-            return function (
-              type: string,
-              listener: EventListenerOrEventListenerObject,
-              options?: boolean | AddEventListenerOptions
-            ) {
-              if (type === "mousedown" && listener instanceof Function && this.hasClass("workspace-tab-header")) {
-                let origListener = listener;
-                listener = event => {
-                  if (event instanceof MouseEvent && (event?.altKey || event?.metaKey)) return;
-                  else origListener(event);
-                };
-              }
-              const result = old.call(this, type, listener, options);
-              return result;
-            };
-          },
-        })
-      );
-    }
-    this.register(
-      around(Workspace.prototype, {
-        splitLeaf(old: any) {
-          return function (
-            source: WorkspaceItem,
-            newLeaf: WorkspaceItem,
-            direction?: SplitDirection,
-            before?: boolean,
-            ...args
-          ) {
-            let result = old.call(this, source, newLeaf, direction, before, ...args);
-            this.trigger("bartender-leaf-split", source, newLeaf);
-            return result;
-          };
-        },
-        changeLayout(old: any) {
-          return async function (workspace: any, ...args): Promise<void> {
-            let result = await old.call(this, workspace, ...args);
-            this.trigger("bartender-workspace-change");
-            return result;
-          };
-        },
-      })
-    );
-    this.register(
-      around(Plugin.prototype, {
-        addStatusBarItem(old: any) {
-          return function (...args): HTMLElement {
-            const result = old.call(this, ...args);
-            this.app.workspace.trigger("status-bar-updated");
-            return result;
-          };
-        },
-        addRibbonIcon(old: any) {
-          return function (...args): HTMLElement {
-            const result = old.call(this, ...args);
-            this.app.workspace.trigger("ribbon-bar-updated");
-            return result;
-          };
-        },
-      })
-    );
-  }
+						return old.call(this, ...args);
+					};
+				},
+			}),
+		);
+		if (Platform.isDesktop) {
+			this.register(
+				around(HTMLDivElement.prototype, {
+					addEventListener(old: any) {
+						return function (
+							type: string,
+							listener: EventListenerOrEventListenerObject,
+							options?: boolean | AddEventListenerOptions,
+						) {
+							if (
+								type === "mousedown" &&
+								listener instanceof Function &&
+								this.hasClass("workspace-tab-header")
+							) {
+								let origListener = listener;
+								listener = (event) => {
+									if (
+										event instanceof MouseEvent &&
+										(event?.altKey || event?.metaKey)
+									)
+										return;
+									else origListener(event);
+								};
+							}
+							const result = old.call(this, type, listener, options);
+							return result;
+						};
+					},
+				}),
+			);
+		}
+		this.register(
+			around(Workspace.prototype, {
+				splitLeaf(old: any) {
+					return function (
+						source: WorkspaceItem,
+						newLeaf: WorkspaceItem,
+						direction?: SplitDirection,
+						before?: boolean,
+						...args
+					) {
+						let result = old.call(
+							this,
+							source,
+							newLeaf,
+							direction,
+							before,
+							...args,
+						);
+						this.trigger("bartender-leaf-split", source, newLeaf);
+						return result;
+					};
+				},
+				changeLayout(old: any) {
+					return async function (workspace: any, ...args): Promise<void> {
+						let result = await old.call(this, workspace, ...args);
+						this.trigger("bartender-workspace-change");
+						return result;
+					};
+				},
+			}),
+		);
+		this.register(
+			around(Plugin.prototype, {
+				addStatusBarItem(old: any) {
+					return function (...args): HTMLElement {
+						const result = old.call(this, ...args);
+						this.app.workspace.trigger("status-bar-updated");
+						return result;
+					};
+				},
+				addRibbonIcon(old: any) {
+					return function (...args): HTMLElement {
+						const result = old.call(this, ...args);
+						this.app.workspace.trigger("ribbon-bar-updated");
+						return result;
+					};
+				},
+			}),
+		);
+	}
 
-  patchFileExplorer(fileExplorer: FileExplorerView) {
-    let plugin = this;
-    let settings = this.settings
-    if (fileExplorer) {
-      let InfinityScroll = fileExplorer.tree.infinityScroll.constructor;
-      // register clear first so that it gets called first onunload
-      this.register(() => this.clearFileExplorerFilter());
-      this.register(
-        around(InfinityScroll.prototype, {
-          compute(old: any) {
-            return function (...args: any[]) {
-              try {
-                if (this.scrollEl.hasClass("nav-files-container")) {
-                  plugin.fileExplorerFilter.call(this,fileExplorer);
-                }
-              } catch (err) {
-                console.log(err)
-              }
-              const result = old.call(this, ...args);
-              return result;
-            };
-          },
-        })
-      );
-      this.register(
-        around(fileExplorer.headerDom.constructor.prototype, {
-          addSortButton(old: any) {
-            return function (...args: any[]) {
-              if (this.navHeaderEl?.parentElement?.dataset?.type === "file-explorer") {
-                plugin.setFileExplorerFilter(this);
-                return addSortButton.call(this,settings, ...args);
-              } else {
-                return old.call(this, ...args);
-              }
-            };
-          },
-        })
-      );
-    }
-  }
+	patchFileExplorer(fileExplorer: FileExplorerView) {
+		let plugin = this;
+		let settings = this.settings;
+		if (fileExplorer) {
+			let InfinityScroll = fileExplorer.tree.infinityScroll.constructor;
+			// register clear first so that it gets called first onunload
+			this.register(() => this.clearFileExplorerFilter());
+			this.register(
+				around(InfinityScroll.prototype, {
+					compute(old: any) {
+						return function (...args: any[]) {
+							try {
+								if (this.scrollEl.hasClass("nav-files-container")) {
+									plugin.fileExplorerFilter.call(this, fileExplorer);
+								}
+							} catch (err) {
+								console.log(err);
+							}
+							const result = old.call(this, ...args);
+							return result;
+						};
+					},
+				}),
+			);
+			this.register(
+				around(fileExplorer.headerDom.constructor.prototype, {
+					addSortButton(old: any) {
+						return function (...args: any[]) {
+							if (
+								this.navHeaderEl?.parentElement?.dataset?.type ===
+								"file-explorer"
+							) {
+								plugin.setFileExplorerFilter(this);
+								return addSortButton.call(this, settings, ...args);
+							} else {
+								return old.call(this, ...args);
+							}
+						};
+					},
+				}),
+			);
+		}
+	}
 
-  insertSeparator(selector: string, className: string, rtl: Boolean, glyphSize: number = 16) {
-    let elements = document.body.querySelectorAll(selector);
-    elements.forEach((el: HTMLElement) => {
-      let getSiblings = rtl ? getPreviousSiblings : getNextSiblings;
-      if (el) {
-        let separator = el.createDiv(`${className} separator`);
-        rtl && el.prepend(separator);
-        let glyphEl = separator.createDiv("glyph");
-        let glyphName = "plus-with-circle"; // this gets replaced using CSS
-        // TODO: Handle mobile icon size differences?
-        setIcon(glyphEl, glyphName, glyphSize);
-        separator.addClass("is-collapsed");
-        this.register(() => separator.detach());
-        let hideTimeout: NodeJS.Timeout;
-        separator.onClickEvent((event: MouseEvent) => {
-          if (separator.hasClass("is-collapsed")) {
-            Array.from(el.children).forEach(el => el.removeClass("is-hidden"));
-            separator.removeClass("is-collapsed");
-          } else {
-            getSiblings(separator).forEach(el => el.addClass("is-hidden"));
-            separator.addClass("is-collapsed");
-          }
-        });
-        el.onmouseenter = ev => {
-          hideTimeout && clearTimeout(hideTimeout);
-        };
-        el.onmouseleave = ev => {
-          if (this.settings.autoHide) {
-            hideTimeout = setTimeout(() => {
-              getSiblings(separator).forEach(el => el.addClass("is-hidden"));
-              separator.addClass("is-collapsed");
-            }, this.settings.autoHideDelay);
-          }
-        };
-        setTimeout(() => {
-          getSiblings(separator).forEach(el => el.addClass("is-hidden"));
-          separator.addClass("is-collapsed");
-        }, 0);
-      }
-    });
-  }
+	insertSeparator(
+		selector: string,
+		className: string,
+		rtl: Boolean,
+		glyphSize: number = 16,
+	) {
+		let elements = document.body.querySelectorAll(selector);
+		elements.forEach((el: HTMLElement) => {
+			let getSiblings = rtl ? getPreviousSiblings : getNextSiblings;
+			if (el) {
+				let separator = el.createDiv(`${className} separator`);
+				rtl && el.prepend(separator);
+				let glyphEl = separator.createDiv("glyph");
+				let glyphName = "plus-with-circle"; // this gets replaced using CSS
+				// TODO: Handle mobile icon size differences?
+				setIcon(glyphEl, glyphName, glyphSize);
+				separator.addClass("is-collapsed");
+				this.register(() => separator.detach());
+				let hideTimeout: NodeJS.Timeout;
+				separator.onClickEvent((event: MouseEvent) => {
+					if (separator.hasClass("is-collapsed")) {
+						Array.from(el.children).forEach((el) =>
+							el.removeClass("is-hidden"),
+						);
+						separator.removeClass("is-collapsed");
+					} else {
+						getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
+						separator.addClass("is-collapsed");
+					}
+				});
+				el.onmouseenter = (ev) => {
+					hideTimeout && clearTimeout(hideTimeout);
+				};
+				el.onmouseleave = (ev) => {
+					if (this.settings.autoHide) {
+						hideTimeout = setTimeout(() => {
+							getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
+							separator.addClass("is-collapsed");
+						}, this.settings.autoHideDelay);
+					}
+				};
+				setTimeout(() => {
+					getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
+					separator.addClass("is-collapsed");
+				}, 0);
+			}
+		});
+	}
 
-  setElementIDs(parentEl: HTMLElement, options: GenerateIdOptions) {
-    Array.from(parentEl.children).forEach(child => {
-      if (child instanceof HTMLElement) {
-        if (!child.getAttribute("data-id")) {
-          child.setAttribute("data-id", generateId(child, options));
-        }
-      }
-    });
-  }
+	setElementIDs(parentEl: HTMLElement, options: GenerateIdOptions) {
+		Array.from(parentEl.children).forEach((child) => {
+			if (child instanceof HTMLElement) {
+				if (!child.getAttribute("data-id")) {
+					child.setAttribute("data-id", generateId(child, options));
+				}
+			}
+		});
+	}
 
-  setTabBarSorter(element: HTMLElement, leaf: WorkspaceTabs) {
-    this.setElementIDs(element, { useClass: true, useIcon: true });
-    let sorter = Sortable.create(element, {
-      group: "leftTabBar",
-      dataIdAttr: "data-id",
-      chosenClass: "bt-sortable-chosen",
-      delay: Platform.isMobile ? 200 : this.settings.dragDelay,
-      dropBubble: false,
-      dragoverBubble: false,
-      animation: ANIMATION_DURATION,
-      onChoose: () => element.parentElement?.addClass("is-dragging"),
-      onUnchoose: () => element.parentElement?.removeClass("is-dragging"),
-      onStart: () => {
-        document.body.addClass("is-dragging");
-        element.querySelector(".separator")?.removeClass("is-collapsed");
-        Array.from(element.children).forEach(el => el.removeClass("is-hidden"));
-      },
-      onEnd: event => {
-        document.body.removeClass("is-dragging");
-        if (event.oldIndex !== undefined && event.newIndex !== undefined) {
-          reorderArray(leaf.children, event.oldIndex, event.newIndex);
-          leaf.currentTab = event.newIndex;
-          leaf.recomputeChildrenDimensions();
-        }
-        this.app.workspace.requestSaveLayout();
-      },
-    });
-    return sorter;
-  }
+	setTabBarSorter(element: HTMLElement, leaf: WorkspaceTabs) {
+		this.setElementIDs(element, { useClass: true, useIcon: true });
+		let sorter = Sortable.create(element, {
+			group: "leftTabBar",
+			dataIdAttr: "data-id",
+			chosenClass: "bt-sortable-chosen",
+			delay: Platform.isMobile ? 200 : this.settings.dragDelay,
+			dropBubble: false,
+			dragoverBubble: false,
+			animation: ANIMATION_DURATION,
+			onChoose: () => element.parentElement?.addClass("is-dragging"),
+			onUnchoose: () => element.parentElement?.removeClass("is-dragging"),
+			onStart: () => {
+				document.body.addClass("is-dragging");
+				element.querySelector(".separator")?.removeClass("is-collapsed");
+				Array.from(element.children).forEach((el) =>
+					el.removeClass("is-hidden"),
+				);
+			},
+			onEnd: (event) => {
+				document.body.removeClass("is-dragging");
+				if (event.oldIndex !== undefined && event.newIndex !== undefined) {
+					reorderArray(leaf.children, event.oldIndex, event.newIndex);
+					leaf.currentTab = event.newIndex;
+					leaf.recomputeChildrenDimensions();
+				}
+				this.app.workspace.requestSaveLayout();
+			},
+		});
+		return sorter;
+	}
 
-  setStatusBarSorter() {
-    let el = document.body.querySelector("body > div.app-container > div.status-bar") as HTMLElement;
-    if (el) {
-      this.setElementIDs(el, { useClass: true, useAria: true, useIcon: true });
-      this.statusBarSorter = Sortable.create(el, {
-        group: "statusBar",
-        dataIdAttr: "data-id",
-        chosenClass: "bt-sortable-chosen",
-        delay: Platform.isMobile ? 200 : this.settings.dragDelay,
-        animation: ANIMATION_DURATION,
-        onChoose: () => {
-          Array.from(el.children).forEach(el => el.removeClass("is-hidden"));
-        },
-        onStart: () => {
-          el.querySelector(".separator")?.removeClass("is-collapsed");
-          Array.from(el.children).forEach(el => el.removeClass("is-hidden"));
-        },
-        store: {
-          get: sortable => {
-            return this.settings.statusBarOrder;
-          },
-          set: s => {
-            this.settings.statusBarOrder = s.toArray();
-            this.saveSettings();
-          },
-        },
-      });
-    }
-  }
+	setStatusBarSorter() {
+		let el = document.body.querySelector(
+			"body > div.app-container > div.status-bar",
+		) as HTMLElement;
+		if (el) {
+			this.setElementIDs(el, { useClass: true, useAria: true, useIcon: true });
+			this.statusBarSorter = Sortable.create(el, {
+				group: "statusBar",
+				dataIdAttr: "data-id",
+				chosenClass: "bt-sortable-chosen",
+				delay: Platform.isMobile ? 200 : this.settings.dragDelay,
+				animation: ANIMATION_DURATION,
+				onChoose: () => {
+					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+				},
+				onStart: () => {
+					el.querySelector(".separator")?.removeClass("is-collapsed");
+					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+				},
+				store: {
+					get: (sortable) => {
+						return this.settings.statusBarOrder;
+					},
+					set: (s) => {
+						this.settings.statusBarOrder = s.toArray();
+						this.saveSettings();
+					},
+				},
+			});
+		}
+	}
 
-  setViewActionSorter(el: HTMLElement, view: View): Sortable | undefined {
-    this.setElementIDs(el, { useClass: true, useIcon: true });
-    let hasSorter = Object.values(el).find(value => value?.hasOwnProperty("nativeDraggable"));
-    if (hasSorter) return undefined;
-    let viewType = view?.getViewType() || "unknown";
-    let sortable = new Sortable(el, {
-      group: "actionBar",
-      dataIdAttr: "data-id",
-      chosenClass: "bt-sortable-chosen",
-      delay: Platform.isMobile ? 200 : this.settings.dragDelay,
-      sort: true,
-      animation: ANIMATION_DURATION,
-      onStart: () => {
-        el.querySelector(".separator")?.removeClass("is-collapsed");
-        Array.from(el.children).forEach(el => el.removeClass("is-hidden"));
-      },
-      store: {
-        get: () => {
-          return this.settings.actionBarOrder[viewType];
-        },
-        set: s => {
-          this.settings.actionBarOrder[viewType] = s.toArray();
-          this.saveSettings();
-        },
-      },
-    });
-    return sortable;
-  }
+	setViewActionSorter(el: HTMLElement, view: View): Sortable | undefined {
+		this.setElementIDs(el, { useClass: true, useIcon: true });
+		let hasSorter = Object.values(el).find((value) =>
+			value?.hasOwnProperty("nativeDraggable"),
+		);
+		if (hasSorter) return undefined;
+		let viewType = view?.getViewType() || "unknown";
+		let sortable = new Sortable(el, {
+			group: "actionBar",
+			dataIdAttr: "data-id",
+			chosenClass: "bt-sortable-chosen",
+			delay: Platform.isMobile ? 200 : this.settings.dragDelay,
+			sort: true,
+			animation: ANIMATION_DURATION,
+			onStart: () => {
+				el.querySelector(".separator")?.removeClass("is-collapsed");
+				Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+			},
+			store: {
+				get: () => {
+					return this.settings.actionBarOrder[viewType];
+				},
+				set: (s) => {
+					this.settings.actionBarOrder[viewType] = s.toArray();
+					this.saveSettings();
+				},
+			},
+		});
+		return sortable;
+	}
 
-  setRibbonBarSorter() {
-    let el = document.body.querySelector("body > div.app-container div.side-dock-actions") as HTMLElement;
-    if (el) {
-      this.setElementIDs(el, { useClass: true, useAria: true, useIcon: true });
-      this.ribbonBarSorter = Sortable.create(el, {
-        group: "ribbonBar",
-        dataIdAttr: "data-id",
-        delay: Platform.isMobile ? 200 : this.settings.dragDelay,
-        chosenClass: "bt-sortable-chosen",
-        animation: ANIMATION_DURATION,
-        onChoose: () => {
-          Array.from(el.children).forEach(el => el.removeClass("is-hidden"));
-        },
-        onStart: () => {
-          el.querySelector(".separator")?.removeClass("is-collapsed");
-          Array.from(el.children).forEach(el => el.removeClass("is-hidden"));
-        },
-        store: {
-          get: sortable => {
-            return this.settings.ribbonBarOrder;
-          },
-          set: s => {
-            this.settings.ribbonBarOrder = s.toArray();
-            this.saveSettings();
-          },
-        },
-      });
-    }
-  }
+	setRibbonBarSorter() {
+		let el = document.body.querySelector(
+			"body > div.app-container div.side-dock-actions",
+		) as HTMLElement;
+		if (el) {
+			this.setElementIDs(el, { useClass: true, useAria: true, useIcon: true });
+			this.ribbonBarSorter = Sortable.create(el, {
+				group: "ribbonBar",
+				dataIdAttr: "data-id",
+				delay: Platform.isMobile ? 200 : this.settings.dragDelay,
+				chosenClass: "bt-sortable-chosen",
+				animation: ANIMATION_DURATION,
+				onChoose: () => {
+					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+				},
+				onStart: () => {
+					el.querySelector(".separator")?.removeClass("is-collapsed");
+					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+				},
+				store: {
+					get: (sortable) => {
+						return this.settings.ribbonBarOrder;
+					},
+					set: (s) => {
+						this.settings.ribbonBarOrder = s.toArray();
+						this.saveSettings();
+					},
+				},
+			});
+		}
+	}
 
-  setFileExplorerFilter(headerDom: FileExplorerHeader) {
-    let fileExplorerNav = headerDom.navHeaderEl;
-    if (fileExplorerNav) {
-      let fileExplorerFilter = fileExplorerNav.createDiv("search-input-container");
-      fileExplorerNav.insertAdjacentElement("afterend", fileExplorerFilter);
-      let fileExplorerFilterInput = fileExplorerFilter.createEl("input");
-      fileExplorerFilterInput.placeholder = "Type to filter...";
-      fileExplorerFilterInput.type = "text";
-      fileExplorerFilter.hide();
-      let filterScope = new Scope(this.app.scope);
-      fileExplorerFilterInput.onfocus = () => {
-        this.app.keymap.pushScope(filterScope);
-      }
-      fileExplorerFilterInput.onblur = () => {
-        this.app.keymap.popScope(filterScope);
-      }
-      fileExplorerFilterInput.oninput = (ev: InputEvent) => {
-        let fileExplorer = this.getFileExplorer();
-        if (ev.target instanceof HTMLInputElement) {
-          if (ev.target.value.length) {
-            clearButtonEl.show();
-          } else {
-            clearButtonEl.hide();
-          }
-          fileExplorer.tree.infinityScroll.filter = ev.target.value;
-        }
-        fileExplorer.tree.infinityScroll.compute();
-      };
-      let clearButtonEl = fileExplorerFilter.createDiv("search-input-clear-button", function (el) {
-        el.addEventListener("click", function () {
-          (fileExplorerFilterInput.value = ""), clearButtonEl.hide();
-          fileExplorerFilterInput.focus();
-          fileExplorerFilterInput.dispatchEvent(new Event("input"));
-        }),
-          el.hide();
-      });
-    }
-  }
+	setFileExplorerFilter(headerDom: FileExplorerHeader) {
+		let fileExplorerNav = headerDom.navHeaderEl;
+		if (fileExplorerNav) {
+			let fileExplorerFilter = fileExplorerNav.createDiv(
+				"search-input-container",
+			);
+			fileExplorerNav.insertAdjacentElement("afterend", fileExplorerFilter);
+			let fileExplorerFilterInput = fileExplorerFilter.createEl("input");
+			fileExplorerFilterInput.placeholder = "Type to filter...";
+			fileExplorerFilterInput.type = "text";
+			fileExplorerFilter.hide();
+			let filterScope = new Scope(this.app.scope);
+			fileExplorerFilterInput.onfocus = () => {
+				this.app.keymap.pushScope(filterScope);
+			};
+			fileExplorerFilterInput.onblur = () => {
+				this.app.keymap.popScope(filterScope);
+			};
+			fileExplorerFilterInput.oninput = (ev: InputEvent) => {
+				let fileExplorer = this.getFileExplorer();
+				if (ev.target instanceof HTMLInputElement) {
+					if (ev.target.value.length) {
+						clearButtonEl.show();
+					} else {
+						clearButtonEl.hide();
+					}
+					fileExplorer.tree.infinityScroll.filter = ev.target.value;
+				}
+				fileExplorer.tree.infinityScroll.compute();
+			};
+			let clearButtonEl = fileExplorerFilter.createDiv(
+				"search-input-clear-button",
+				function (el) {
+					el.addEventListener("click", function () {
+						(fileExplorerFilterInput.value = ""), clearButtonEl.hide();
+						fileExplorerFilterInput.focus();
+						fileExplorerFilterInput.dispatchEvent(new Event("input"));
+					}),
+						el.hide();
+				},
+			);
+		}
+	}
 
-  setFileExplorerSorter(fileExplorer?: FileExplorerView) {
-    // TODO: Register sorter on new folder creation
-    // TODO: Unregister sorter on folder deletion
-    if (!fileExplorer) fileExplorer = this.getFileExplorer();
-    if (!fileExplorer || this.settings.sortOrder !== "custom" || fileExplorer.hasCustomSorter) return;
-    let roots = this.getRootFolders(fileExplorer);
-    if (!roots || !roots.length) return;
-    for (let root of roots) {
-      let el = root?.childrenEl;
-      if (!el) continue;
-      let draggedItems: HTMLElement[];
-      fileExplorer.hasCustomSorter = true;
-      let dragEnabled = document.body.querySelector("div.nav-action-button.drag-to-rearrange")?.hasClass("is-active")
-        ? true
-        : false;
-      root.sorter = Sortable.create(el!, {
-        group: "fileExplorer" + root.file.path,
-        forceFallback: true,
-        multiDrag: true,
-        // @ts-ignore
-        multiDragKey: "alt",
-        // selectedClass: "is-selected",
-        chosenClass: "bt-sortable-chosen",
-        delay: 0,
-        disabled: !dragEnabled,
-        sort: dragEnabled, // init with dragging disabled. the nav bar button will toggle on/off
-        animation: ANIMATION_DURATION,
-        onStart: evt => {
-          if (evt.items.length) {
-            draggedItems = evt.items;
-          } else {
-            draggedItems = [evt.item];
-          }
-        },
-        onMove: evt => {
-          // TODO: Refactor this
-          // Responsible for updating the internal Obsidian array that contains the file item order
-          // Without this logic, reordering is ephemeral and will be undone by Obisidian's native processes
-          const supportsVirtualChildren = requireApiVersion && requireApiVersion("0.15.0");
-          let _children = supportsVirtualChildren ? root.vChildren?._children : root.children;
-          if (!_children || !draggedItems?.length) return;
-          let children = _children.map(child => child.el);
-          let adjacentEl = evt.related;
-          let targetIndex = children.indexOf(adjacentEl);
-          let firstItem = draggedItems.first();
-          let firstItemIndex = children.indexOf(firstItem!);
-          let _draggedItems = draggedItems.slice();
-          if (firstItemIndex > targetIndex) _draggedItems.reverse();
-          for (let item of _draggedItems) {
-            let itemIndex = children.indexOf(item);
-            _children = reorderArray(_children, itemIndex, targetIndex);
-            children = reorderArray(children, itemIndex, targetIndex);
-          }
-          this.settings.fileExplorerOrder[root.file.path] = _children.map(child => child.file.path);
-          this.saveSettings();
-          // return !adjacentEl.hasClass("nav-folder");
-        },
-        onEnd: evt => {
-          draggedItems = [];
-          document.querySelector("body>div.drag-ghost")?.detach();
-        },
-      });
-    }
-  }
+	setFileExplorerSorter(fileExplorer?: FileExplorerView) {
+		// TODO: Register sorter on new folder creation
+		// TODO: Unregister sorter on folder deletion
+		if (!fileExplorer) fileExplorer = this.getFileExplorer();
+		if (
+			!fileExplorer ||
+			this.settings.sortOrder !== "custom" ||
+			fileExplorer.hasCustomSorter
+		)
+			return;
+		let roots = this.getRootFolders(fileExplorer);
+		if (!roots || !roots.length) return;
+		for (let root of roots) {
+			let el = root?.childrenEl;
+			if (!el) continue;
+			let draggedItems: HTMLElement[];
+			fileExplorer.hasCustomSorter = true;
+			let dragEnabled = document.body
+				.querySelector("div.nav-action-button.drag-to-rearrange")
+				?.hasClass("is-active")
+				? true
+				: false;
+			if (root.file?.path) {
+				root.sorter = Sortable.create(el!, {
+					group: "fileExplorer" + root.file.path,
+					forceFallback: true,
+					multiDrag: true,
+					// @ts-ignore
+					multiDragKey: "alt",
+					// selectedClass: "is-selected",
+					chosenClass: "bt-sortable-chosen",
+					delay: 0,
+					disabled: !dragEnabled,
+					sort: dragEnabled, // init with dragging disabled. the nav bar button will toggle on/off
+					animation: ANIMATION_DURATION,
+					onStart: (evt) => {
+						if (evt.items.length) {
+							draggedItems = evt.items;
+						} else {
+							draggedItems = [evt.item];
+						}
+					},
+					onMove: (evt) => {
+						// TODO: Refactor this
+						// Responsible for updating the internal Obsidian array that contains the file item order
+						// Without this logic, reordering is ephemeral and will be undone by Obisidian's native processes
+						const supportsVirtualChildren =
+							requireApiVersion && requireApiVersion("0.15.0");
+						let _children = supportsVirtualChildren
+							? root.vChildren?._children
+							: root.children;
+						if (!_children || !draggedItems?.length) return;
+						let children = _children.map((child) => child.el);
+						let adjacentEl = evt.related;
+						let targetIndex = children.indexOf(adjacentEl);
+						let firstItem = draggedItems.first();
+						let firstItemIndex = children.indexOf(firstItem!);
+						let _draggedItems = draggedItems.slice();
+						if (firstItemIndex > targetIndex) _draggedItems.reverse();
+						for (let item of _draggedItems) {
+							let itemIndex = children.indexOf(item);
+							_children = reorderArray(_children, itemIndex, targetIndex);
+							children = reorderArray(children, itemIndex, targetIndex);
+						}
+						this.settings.fileExplorerOrder[root.file.path] = _children.map(
+							(child) => child.file.path,
+						);
+						this.saveSettings();
+						// return !adjacentEl.hasClass("nav-folder");
+					},
+					onEnd: (evt) => {
+						draggedItems = [];
+						document.querySelector("body>div.drag-ghost")?.detach();
+					},
+				});
+			}
+		}
+	}
 
-  getFileExplorer() {
-    let fileExplorer: FileExplorerView | undefined = this.app.workspace.getLeavesOfType("file-explorer")?.first()
-      ?.view as unknown as FileExplorerView;
-    return fileExplorer;
-  }
+	getFileExplorer() {
+		let fileExplorer: FileExplorerView | undefined = this.app.workspace
+			.getLeavesOfType("file-explorer")
+			?.first()?.view as unknown as FileExplorerView;
+		return fileExplorer;
+	}
 
-  getRootFolders(fileExplorer?: FileExplorerView): [RootElements | ChildElement] | undefined {
-    if (!fileExplorer) fileExplorer = this.getFileExplorer();
-    if (!fileExplorer) return;
-    let root = fileExplorer.tree?.infinityScroll?.rootEl;
-    let roots = root && this.traverseRoots(root);
-    return roots;
-  }
+	getRootFolders(
+		fileExplorer?: FileExplorerView,
+	): [RootElements | ChildElement] | undefined {
+		if (!fileExplorer) fileExplorer = this.getFileExplorer();
+		if (!fileExplorer) return;
+		let root = fileExplorer.tree?.infinityScroll?.rootEl;
+		let roots = root && this.traverseRoots(root);
+		return roots;
+	}
 
-  traverseRoots(root: RootElements | ChildElement, items?: [RootElements | ChildElement]) {
-    if (!items) items = [root];
-    const supportsVirtualChildren = requireApiVersion && requireApiVersion("0.15.0");
-    const _children = supportsVirtualChildren ? root.vChildren?._children : root.children;
-    for (let child of _children || []) {
-      if (child.children || child.vChildren?._children) {
-        items.push(child);
-      }
-      this.traverseRoots(child, items);
-    }
-    return items;
-  }
+	traverseRoots(
+		root: RootElements | ChildElement,
+		items?: [RootElements | ChildElement],
+	) {
+		if (!items) items = [root];
+		const supportsVirtualChildren =
+			requireApiVersion && requireApiVersion("0.15.0");
+		const _children = supportsVirtualChildren
+			? root.vChildren?._children
+			: root.children;
+		for (let child of _children || []) {
+			if (child.children || child.vChildren?._children) {
+				items.push(child);
+			}
+			this.traverseRoots(child, items);
+		}
+		return items;
+	}
 
-  toggleFileExplorerSorters(enable: boolean) {
-    let fileExplorer = this.getFileExplorer();
-    let roots = this.getRootFolders(fileExplorer);
-    if (roots?.length) {
-      for (let root of roots) {
-        if (root.sorter) {
-          root.sorter.option("sort", enable);
-          root.sorter.option("disabled", !enable);
-        }
-      }
-    }
-  }
+	toggleFileExplorerSorters(enable: boolean) {
+		let fileExplorer = this.getFileExplorer();
+		let roots = this.getRootFolders(fileExplorer);
+		if (roots?.length) {
+			for (let root of roots) {
+				if (root.sorter) {
+					root.sorter.option("sort", enable);
+					root.sorter.option("disabled", !enable);
+				}
+			}
+		}
+	}
 
-  cleanupFileExplorerSorters() {
-    let fileExplorer = this.getFileExplorer();
-    let roots = this.getRootFolders(fileExplorer);
-    if (roots?.length) {
-      for (let root of roots) {
-        if (root.sorter) {
-          root.sorter.destroy();
-          delete root.sorter;
-          Object.keys(root.childrenEl!).forEach(
-            key => key.startsWith("Sortable") && delete (root.childrenEl as any)[key]
-          );
-          // sortable.destroy removes all of the draggble attributes :( so we put them back
-          root
-            .childrenEl!.querySelectorAll("div.nav-file-title")
-            .forEach((el: HTMLDivElement) => (el.draggable = true));
-          root
-            .childrenEl!.querySelectorAll("div.nav-folder-title")
-            .forEach((el: HTMLDivElement) => (el.draggable = true));
-        }
-      }
-    }
-    delete fileExplorer.hasCustomSorter;
-    // unset "custom" file explorer sort
-    if (this.app.vault.getConfig("fileSortOrder") === "custom") {
-      fileExplorer.setSortOrder("alphabetical");
-    }
-  }
+	cleanupFileExplorerSorters() {
+		let fileExplorer = this.getFileExplorer();
+		let roots = this.getRootFolders(fileExplorer);
+		if (roots?.length) {
+			for (let root of roots) {
+				if (root.sorter) {
+					root.sorter.destroy();
+					delete root.sorter;
+					Object.keys(root.childrenEl!).forEach(
+						(key) =>
+							key.startsWith("Sortable") &&
+							delete (root.childrenEl as any)[key],
+					);
+					// sortable.destroy removes all of the draggble attributes :( so we put them back
+					root
+						.childrenEl!.querySelectorAll("div.nav-file-title")
+						.forEach((el: HTMLDivElement) => (el.draggable = true));
+					root
+						.childrenEl!.querySelectorAll("div.nav-folder-title")
+						.forEach((el: HTMLDivElement) => (el.draggable = true));
+				}
+			}
+		}
+		delete fileExplorer.hasCustomSorter;
+		// unset "custom" file explorer sort
+		if (this.app.vault.getConfig("fileSortOrder") === "custom") {
+			fileExplorer.setSortOrder("alphabetical");
+		}
+	}
 
-  onunload(): void {
-    this.statusBarSorter?.destroy();
-    this.ribbonBarSorter?.destroy();
-    this.app.workspace.iterateAllLeaves(leaf => {
-      let sorterParent: View | WorkspaceTabs | WorkspaceLeaf | boolean;
-      if (
-        (sorterParent = leaf?.iconSorter ? leaf : false) ||
-        (sorterParent = leaf?.view?.iconSorter ? leaf.view : false) ||
-        (sorterParent =
-          leaf?.parentSplit instanceof WorkspaceTabs && leaf?.parentSplit?.iconSorter ? leaf?.parentSplit : false)
-      ) {
-        try {
-          sorterParent.iconSorter?.destroy();
-        } catch (err) {
-        } finally {
-          delete sorterParent.iconSorter;
-        }
-      }
-    });
+	onunload(): void {
+		this.statusBarSorter?.destroy();
+		this.ribbonBarSorter?.destroy();
+		this.app.workspace.iterateAllLeaves((leaf) => {
+			let sorterParent: View | WorkspaceTabs | WorkspaceLeaf | boolean;
+			if (
+				(sorterParent = leaf?.iconSorter ? leaf : false) ||
+				(sorterParent = leaf?.view?.iconSorter ? leaf.view : false) ||
+				(sorterParent =
+					leaf?.parentSplit instanceof WorkspaceTabs &&
+					leaf?.parentSplit?.iconSorter
+						? leaf?.parentSplit
+						: false)
+			) {
+				try {
+					sorterParent.iconSorter?.destroy();
+				} catch (err) {
+				} finally {
+					delete sorterParent.iconSorter;
+				}
+			}
+		});
 
-    // clean up file explorer sorters
-    this.cleanupFileExplorerSorters();
-  }
+		// clean up file explorer sorters
+		this.cleanupFileExplorerSorters();
+	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,37 +1,41 @@
 import Fuse from "fuse.js";
 import { around } from "monkey-around";
 import {
-	type ChildElement,
-	type FileExplorerHeader,
-	type FileExplorerView,
-	Platform,
-	Plugin,
-	type RootElements,
-	Scope,
-	setIcon,
-	type SplitDirection,
-	View,
-	type ViewCreator,
-	Workspace,
-	type WorkspaceItem,
-	WorkspaceLeaf,
-	type WorkspaceSplit,
-	WorkspaceTabs,
-	requireApiVersion,
+  ChildElement,
+  FileExplorerHeader,
+  FileExplorerView,
+  Platform,
+  Plugin,
+  RootElements,
+  Scope,
+  setIcon,
+  SplitDirection,
+  View,
+  ViewCreator,
+  Workspace,
+  WorkspaceItem,
+  WorkspaceLeaf,
+  WorkspaceSplit,
+  WorkspaceTabs,
+  requireApiVersion,
 } from "obsidian";
 
 import Sortable, { MultiDrag } from "sortablejs";
 import { addSortButton, folderSortV2 } from "./file-explorer/custom-sort";
-import { type BartenderSettings, DEFAULT_SETTINGS, SettingTab } from "./settings/settings";
 import {
-	generateId,
-	type GenerateIdOptions,
-	getFn,
-	getItems,
-	getNextSiblings,
-	getPreviousSiblings,
-	highlight,
-	reorderArray,
+  BartenderSettings,
+  DEFAULT_SETTINGS,
+  SettingTab,
+} from "./settings/settings";
+import {
+  generateId,
+  GenerateIdOptions,
+  getFn,
+  getItems,
+  getNextSiblings,
+  getPreviousSiblings,
+  highlight,
+  reorderArray,
 } from "./utils";
 
 Sortable.mount(new MultiDrag());
@@ -41,854 +45,897 @@ const RIBBON_BAR_SELECTOR = "body > div.app-container div.side-dock-actions";
 const ANIMATION_DURATION = 500;
 
 export default class BartenderPlugin extends Plugin {
-	statusBarSorter: Sortable;
-	ribbonBarSorter: Sortable;
-	fileSorter: Sortable;
-	separator: HTMLElement;
-	settings: BartenderSettings;
-	settingsTab: SettingTab;
+  statusBarSorter: Sortable;
+  ribbonBarSorter: Sortable;
+  fileSorter: Sortable;
+  separator: HTMLElement;
+  settings: BartenderSettings;
+  settingsTab: SettingTab;
 
-	async onload() {
-		await this.loadSettings();
-		this.registerMonkeyPatches();
-		this.registerEventHandlers();
-		this.registerSettingsTab();
-		this.initialize();
+  async onload() {
+    await this.loadSettings();
+    this.registerMonkeyPatches();
+    this.registerEventHandlers();
+    this.registerSettingsTab();
+    this.initialize();
 
-		this.app.vault.on("rename", async (file, oldFile) => {
-			// change the path in the settings
-			//first check if folder and search this path in the settings
-			console.log("file", file, "oldFile", oldFile);
-			for (const key in this.settings.fileExplorerOrder) {
-				for (const item of this.settings.fileExplorerOrder[key]) {
-					if (item === oldFile) {
-						const index = this.settings.fileExplorerOrder[key].indexOf(item);
-						this.settings.fileExplorerOrder[key][index] = file.path;
-					}
-				}
-				if (key.startsWith(oldFile)) {
-					this.settings.fileExplorerOrder[file.path] =
-						this.settings.fileExplorerOrder[key];
-					delete this.settings.fileExplorerOrder[key];
-				}
-			}
-			await this.saveSettings();
-		});
+    this.app.vault.on("rename", async (file, oldFile) => {
+      // change the path in the settings
+      //first check if folder and search this path in the settings
+      console.log("file", file, "oldFile", oldFile);
+      for (const key in this.settings.fileExplorerOrder) {
+        for (const item of this.settings.fileExplorerOrder[key]) {
+          if (item === oldFile) {
+            const index = this.settings.fileExplorerOrder[key].indexOf(item);
+            this.settings.fileExplorerOrder[key][index] = file.path;
+          }
+        }
+        if (key.startsWith(oldFile)) {
+          this.settings.fileExplorerOrder[file.path] =
+            this.settings.fileExplorerOrder[key];
+          delete this.settings.fileExplorerOrder[key];
+        }
+      }
+      await this.saveSettings();
+    });
 
-		this.app.vault.on("delete", async (file) => {
-			// remove the path from the settings
-			console.log("file", file);
-			for (const key in this.settings.fileExplorerOrder) {
-				for (const item of this.settings.fileExplorerOrder[key]) {
-					if (item === file.path) {
-						const index = this.settings.fileExplorerOrder[key].indexOf(item);
-						console.log("index", index);
-						this.settings.fileExplorerOrder[key].splice(index, 1);
-					}
-				}
-				if (key.startsWith(file.path)) {
-					delete this.settings.fileExplorerOrder[key];
-				}
-			}
-			await this.saveSettings();
-		});
-	}
+    this.app.vault.on("delete", async (file) => {
+      // remove the path from the settings
+      console.log("file", file);
+      for (const key in this.settings.fileExplorerOrder) {
+        for (const item of this.settings.fileExplorerOrder[key]) {
+          if (item === file.path) {
+            const index = this.settings.fileExplorerOrder[key].indexOf(item);
+            console.log("index", index);
+            this.settings.fileExplorerOrder[key].splice(index, 1);
+          }
+        }
+        if (key.startsWith(file.path)) {
+          delete this.settings.fileExplorerOrder[key];
+        }
+      }
+      await this.saveSettings();
+    });
+  }
 
-	async loadSettings() {
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-	}
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
 
-	async saveSettings() {
-		await this.saveData(this.settings);
-	}
+  async saveSettings() {
+    await this.saveData(this.settings);
+  }
 
-	patchFileExplorerFolder() {
-		const plugin = this;
-		const leaf = plugin.app.workspace.getLeaf(true);
-		const fileExplorer = plugin.app.viewRegistry.viewByType["file-explorer"](
-			leaf
-		) as FileExplorerView;
-		this.register(
-			around(fileExplorer.constructor.prototype, {
-				getSortedFolderItems: (old: any) => {
-					return function (...args: any[]) {
-						if (plugin.settings.sortOrder === "custom") {
-							return folderSortV2.call(this, plugin.settings, ...args);
-						}
-						return old.call(this, ...args);
-					};
-				},
-			})
-		);
+  patchFileExplorerFolder() {
+    const plugin = this;
+    const leaf = plugin.app.workspace.getLeaf(true);
+    const fileExplorer = plugin.app.viewRegistry.viewByType["file-explorer"](
+      leaf
+    ) as FileExplorerView;
+    this.register(
+      around(fileExplorer.constructor.prototype, {
+        getSortedFolderItems: (old: any) => {
+          return function (...args: any[]) {
+            if (plugin.settings.sortOrder === "custom") {
+              return folderSortV2.call(this, plugin.settings, ...args);
+            }
+            return old.call(this, ...args);
+          };
+        },
+      })
+    );
 
-		leaf.detach();
-	}
+    leaf.detach();
+  }
 
-	initialize() {
-		this.app.workspace.onLayoutReady(() => {
-			this.patchFileExplorerFolder();
-			setTimeout(
-				() => {
-					if (Platform.isDesktop && this.settings.useCollapse) {
-						// add sorter to the status bar
-						this.insertSeparator(STATUS_BAR_SELECTOR, "status-bar-item", true);
-						this.setStatusBarSorter();
+  initialize() {
+    this.app.workspace.onLayoutReady(() => {
+      this.patchFileExplorerFolder();
+      setTimeout(
+        () => {
+          if (Platform.isDesktop && this.settings.useCollapse) {
+            // add sorter to the status bar
+            this.insertSeparator(STATUS_BAR_SELECTOR, "status-bar-item", true);
+            this.setStatusBarSorter();
 
-						// add sorter to the sidebar tabs
-						if (requireApiVersion && !requireApiVersion("0.15.3")) {
-							const left = (this.app.workspace.leftSplit as WorkspaceSplit).children;
-							const right = (this.app.workspace.rightSplit as WorkspaceSplit).children;
-							left.concat(right).forEach((child) => {
-								if (child.hasOwnProperty("tabsInnerEl") && !child.iconSorter) {
-									child.iconSorter = this.setTabBarSorter(child.tabsInnerEl, child);
-								}
-							});
-						}
-					}
+            // add sorter to the sidebar tabs
+            if (requireApiVersion && !requireApiVersion("0.15.3")) {
+              const left = (this.app.workspace.leftSplit as WorkspaceSplit)
+                .children;
+              const right = (this.app.workspace.rightSplit as WorkspaceSplit)
+                .children;
+              left.concat(right).forEach((child) => {
+                if (child.hasOwnProperty("tabsInnerEl") && !child.iconSorter) {
+                  child.iconSorter = this.setTabBarSorter(
+                    child.tabsInnerEl,
+                    child
+                  );
+                }
+              });
+            }
+          }
 
-					// add file explorer sorter
-					this.setFileExplorerSorter();
+          // add file explorer sorter
+          this.setFileExplorerSorter();
 
-					// add sorter to the left sidebar ribbon
-					if (this.settings.useCollapse) {
-						this.insertSeparator(RIBBON_BAR_SELECTOR, "side-dock-ribbon-action", false);
-						this.setRibbonBarSorter();
-					}
+          // add sorter to the left sidebar ribbon
+          if (this.settings.useCollapse) {
+            this.insertSeparator(
+              RIBBON_BAR_SELECTOR,
+              "side-dock-ribbon-action",
+              false
+            );
+            this.setRibbonBarSorter();
+          }
 
-					// add sorter to all view actions icon groups
-					this.app.workspace.iterateRootLeaves((leaf) => {
-						if (
-							leaf?.view?.hasOwnProperty("actionsEl") &&
-							!leaf?.view?.hasOwnProperty("iconSorter")
-						) {
-							leaf.view.iconSorter = this.setViewActionSorter(
-								leaf.view.actionsEl,
-								leaf.view
-							);
-						}
-					});
-				},
-				Platform.isMobile ? 3000 : 400
-			); // give time for plugins like Customizable Page Header to add their icons
-		});
-	}
+          // add sorter to all view actions icon groups
+          this.app.workspace.iterateRootLeaves((leaf) => {
+            if (
+              leaf?.view?.hasOwnProperty("actionsEl") &&
+              !leaf?.view?.hasOwnProperty("iconSorter")
+            ) {
+              leaf.view.iconSorter = this.setViewActionSorter(
+                leaf.view.actionsEl,
+                leaf.view
+              );
+            }
+          });
+        },
+        Platform.isMobile ? 3000 : 400
+      ); // give time for plugins like Customizable Page Header to add their icons
+    });
+  }
 
-	registerSettingsTab() {
-		this.settingsTab = new SettingTab(this.app, this);
-		this.addSettingTab(this.settingsTab);
-	}
+  registerSettingsTab() {
+    this.settingsTab = new SettingTab(this.app, this);
+    this.addSettingTab(this.settingsTab);
+  }
 
-	clearFileExplorerFilter() {
-		const fileExplorer = this.getFileExplorer();
-		const fileExplorerFilterEl: HTMLInputElement | null = document.body.querySelector(
-			'.workspace-leaf-content[data-type="file-explorer"] .search-input-container > input'
-		);
-		if (fileExplorerFilterEl) fileExplorerFilterEl.value = "";
-		fileExplorer.tree.infinityScroll.filter = "";
-		fileExplorer.tree.infinityScroll.compute();
-	}
+  clearFileExplorerFilter() {
+    const fileExplorer = this.getFileExplorer();
+    const fileExplorerFilterEl: HTMLInputElement | null =
+      document.body.querySelector(
+        '.workspace-leaf-content[data-type="file-explorer"] .search-input-container > input'
+      );
+    if (fileExplorerFilterEl) fileExplorerFilterEl.value = "";
+    fileExplorer.tree.infinityScroll.filter = "";
+    fileExplorer.tree.infinityScroll.compute();
+  }
 
-	fileExplorerFilter = function (fileExplorer: FileExplorerView) {
-		const supportsVirtualChildren = requireApiVersion?.("0.15.0");
-		/*    let leaf = this?.rootEl?.view?.app.workspace.getLeaf(true);
+  fileExplorerFilter = function (fileExplorer: FileExplorerView) {
+    const supportsVirtualChildren = requireApiVersion?.("0.15.0");
+    /*    let leaf = this?.rootEl?.view?.app.workspace.getLeaf(true);
     let fileExplorer = this?.rootEl?.view?.app.viewRegistry.viewByType["file-explorer"](leaf) as FileExplorerView;*/
 
-		//let fileExplorer = this?.rootEl?.fileExplorer;
+    //let fileExplorer = this?.rootEl?.fileExplorer;
 
-		if (!fileExplorer) return;
-		const _children = supportsVirtualChildren
-			? this.rootEl?.vChildren._children
-			: this.rootEl?.children;
-		if (!_children) return;
-		if (this.filter?.length >= 1) {
-			if (!this.filtered) {
-				this.rootEl._children = _children;
-				this.filtered = true;
-			}
-			const options = {
-				includeScore: true,
-				includeMatches: true,
-				useExtendedSearch: true,
-				getFn,
-				threshold: 0.1,
-				ignoreLocation: true,
-				keys: ["file.path"],
-			};
-			const flattenedItems = getItems(this.rootEl._children);
-			const fuse = new Fuse(flattenedItems, options);
-			const maxResults = 200;
-			const results = fuse.search(this.filter).slice(0, maxResults);
-			if (supportsVirtualChildren) {
-				this.rootEl.vChildren._children = highlight(results);
-			} else {
-				this.rootEl.children = highlight(results);
-			}
-			return;
-		}
-		if (!(this.filter?.length < 1 && this.filtered)) {
-			return;
-		}
-		if (this.rootEl._children) {
-			if (supportsVirtualChildren) {
-				this.rootEl.vChildren._children = this.rootEl._children;
-			} else {
-				this.rootEl.children = this.rootEl._children;
-			}
-		}
+    if (!fileExplorer) return;
+    const _children = supportsVirtualChildren
+      ? this.rootEl?.vChildren._children
+      : this.rootEl?.children;
+    if (!_children) return;
+    if (this.filter?.length >= 1) {
+      if (!this.filtered) {
+        this.rootEl._children = _children;
+        this.filtered = true;
+      }
+      const options = {
+        includeScore: true,
+        includeMatches: true,
+        useExtendedSearch: true,
+        getFn,
+        threshold: 0.1,
+        ignoreLocation: true,
+        keys: ["file.path"],
+      };
+      const flattenedItems = getItems(this.rootEl._children);
+      const fuse = new Fuse(flattenedItems, options);
+      const maxResults = 200;
+      const results = fuse.search(this.filter).slice(0, maxResults);
+      if (supportsVirtualChildren) {
+        this.rootEl.vChildren._children = highlight(results);
+      } else {
+        this.rootEl.children = highlight(results);
+      }
+      return;
+    }
+    if (!(this.filter?.length < 1 && this.filtered)) {
+      return;
+    }
+    if (this.rootEl._children) {
+      if (supportsVirtualChildren) {
+        this.rootEl.vChildren._children = this.rootEl._children;
+      } else {
+        this.rootEl.children = this.rootEl._children;
+      }
+    }
 
-		const flattenedItems = getItems(this.rootEl._children);
-		flattenedItems.map((match: ChildElement) => {
-			if (!(<any>match).innerEl.origContent) {
-				return;
-			}
-			// @ts-ignore
-			match.innerEl.setText((<any>match).innerEl.origContent);
-			delete (<any>match).innerEl.origContent;
-			// @ts-ignore
-			match.innerEl.removeClass("has-matches");
-		});
+    const flattenedItems = getItems(this.rootEl._children);
+    flattenedItems.map((match: ChildElement) => {
+      if (!(<any>match).innerEl.origContent) {
+        return;
+      }
+      // @ts-ignore
+      match.innerEl.setText((<any>match).innerEl.origContent);
+      delete (<any>match).innerEl.origContent;
+      // @ts-ignore
+      match.innerEl.removeClass("has-matches");
+    });
 
-		this.filtered = false;
-	};
+    this.filtered = false;
+  };
 
-	registerEventHandlers() {
-		this.registerEvent(
-			this.app.workspace.on("file-explorer-draggable-change", (value) => {
-				this.toggleFileExplorerSorters(value);
-			})
-		);
-		this.registerEvent(
-			this.app.workspace.on("file-explorer-sort-change", (sortMethod: string) => {
-				this.settings.sortOrder = sortMethod;
-				this.saveSettings();
-				if (sortMethod === "custom") {
-					setTimeout(() => {
-						this.setFileExplorerSorter();
-					}, 10);
-				} else {
-					this.cleanupFileExplorerSorters();
-				}
-			})
-		);
-		this.registerEvent(
-			this.app.workspace.on("file-explorer-load", (fileExplorer: FileExplorerView) => {
-				setTimeout(() => {
-					this.setFileExplorerSorter(fileExplorer);
-				}, 1000);
-			})
-		);
-		this.registerEvent(
-			this.app.workspace.on(
-				"bartender-leaf-split",
-				(_originLeaf: WorkspaceItem, newLeaf: WorkspaceItem) => {
-					const element: HTMLElement = newLeaf.tabsInnerEl as HTMLElement;
-					if (newLeaf.type === "tabs" && newLeaf instanceof WorkspaceTabs) {
-						if (requireApiVersion && !requireApiVersion("0.15.3")) {
-							this.setTabBarSorter(element, newLeaf);
-						}
-					}
-				}
-			)
-		);
+  registerEventHandlers() {
+    this.registerEvent(
+      this.app.workspace.on("file-explorer-draggable-change", (value) => {
+        this.toggleFileExplorerSorters(value);
+      })
+    );
+    this.registerEvent(
+      this.app.workspace.on(
+        "file-explorer-sort-change",
+        (sortMethod: string) => {
+          this.settings.sortOrder = sortMethod;
+          this.saveSettings();
+          if (sortMethod === "custom") {
+            setTimeout(() => {
+              this.setFileExplorerSorter();
+            }, 10);
+          } else {
+            this.cleanupFileExplorerSorters();
+          }
+        }
+      )
+    );
+    this.registerEvent(
+      this.app.workspace.on(
+        "file-explorer-load",
+        (fileExplorer: FileExplorerView) => {
+          setTimeout(() => {
+            this.setFileExplorerSorter(fileExplorer);
+          }, 1000);
+        }
+      )
+    );
+    this.registerEvent(
+      this.app.workspace.on(
+        "bartender-leaf-split",
+        (_originLeaf: WorkspaceItem, newLeaf: WorkspaceItem) => {
+          const element: HTMLElement = newLeaf.tabsInnerEl as HTMLElement;
+          if (newLeaf.type === "tabs" && newLeaf instanceof WorkspaceTabs) {
+            if (requireApiVersion && !requireApiVersion("0.15.3")) {
+              this.setTabBarSorter(element, newLeaf);
+            }
+          }
+        }
+      )
+    );
 
-		this.registerEvent(
-			this.app.workspace.on("ribbon-bar-updated", () => {
-				setTimeout(() => {
-					if (this.settings.ribbonBarOrder && this.ribbonBarSorter) {
-						this.setElementIDs(this.ribbonBarSorter.el, {
-							useClass: true,
-							useAria: true,
-							useIcon: true,
-						});
-						this.ribbonBarSorter.sort(this.settings.ribbonBarOrder);
-					}
-				}, 0);
-			})
-		);
-		this.registerEvent(
-			this.app.workspace.on("status-bar-updated", () => {
-				setTimeout(() => {
-					if (this.settings.statusBarOrder && this.statusBarSorter) {
-						this.setElementIDs(this.statusBarSorter.el, {
-							useClass: true,
-							useIcon: true,
-						});
-						this.statusBarSorter.sort(this.settings.statusBarOrder);
-					}
-				}, 0);
-			})
-		);
-	}
+    this.registerEvent(
+      this.app.workspace.on("ribbon-bar-updated", () => {
+        setTimeout(() => {
+          if (this.settings.ribbonBarOrder && this.ribbonBarSorter) {
+            this.setElementIDs(this.ribbonBarSorter.el, {
+              useClass: true,
+              useAria: true,
+              useIcon: true,
+            });
+            this.ribbonBarSorter.sort(this.settings.ribbonBarOrder);
+          }
+        }, 0);
+      })
+    );
+    this.registerEvent(
+      this.app.workspace.on("status-bar-updated", () => {
+        setTimeout(() => {
+          if (this.settings.statusBarOrder && this.statusBarSorter) {
+            this.setElementIDs(this.statusBarSorter.el, {
+              useClass: true,
+              useIcon: true,
+            });
+            this.statusBarSorter.sort(this.settings.statusBarOrder);
+          }
+        }, 0);
+      })
+    );
+  }
 
-	registerMonkeyPatches() {
-		const plugin = this;
-		this.register(
-			around(this.app.viewRegistry.constructor.prototype, {
-				registerView(old: any) {
-					return function (type: string, viewCreator: ViewCreator, ...args: unknown[]) {
-						plugin.app.workspace.trigger("view-registered", type, viewCreator);
-						return old.call(this, type, viewCreator, ...args);
-					};
-				},
-			})
-		);
-		// This catches the initial FE view registration so that we can patch the sort button creation logic before
-		// the button is created
-		// TODO: Add conditional logic to patch the sort button even if we don't catch the initial startup
-		// 1) If layout ready, get the existing FE instance, create a patched button, and hide the existing button
-		// 2) Patch `addSortButton` to emit an event
-		// 3) On event,
-		if (this.app.workspace.layoutReady) {
-			const fileExplorer = this.getFileExplorer();
-			this.patchFileExplorer(fileExplorer);
-		} else {
-			const eventRef = this.app.workspace.on(
-				"view-registered",
-				(type: string, viewCreator: ViewCreator) => {
-					if (type !== "file-explorer") return;
-					this.app.workspace.offref(eventRef);
-					// @ts-ignore we need a leaf before any leafs exists in the workspace, so we create one from scratch
-					const leaf = new WorkspaceLeaf(plugin.app);
-					const fileExplorer = viewCreator(leaf) as FileExplorerView;
-					this.patchFileExplorer(fileExplorer);
-				}
-			);
-		}
-		this.register(
-			around(View.prototype, {
-				onunload(old: any) {
-					return function (...args) {
-						try {
-							if (this.iconSorter) {
-								this.iconSorter.destroy();
-								this.iconSorter = null;
-							}
-						} catch {
-							//pass
-						}
-						return old.call(this, ...args);
-					};
-				},
-				onload(old: any) {
-					return function (...args) {
-						setTimeout(() => {
-							if (this.app.workspace.layoutReady) {
-								try {
-									if (
-										!(this.leaf.parentSplit instanceof WorkspaceTabs) &&
-										this.hasOwnProperty("actionsEl") &&
-										!this.iconSorter
-									) {
-										this.iconSorter = plugin.setViewActionSorter(this.actionsEl, this);
-									}
-								} catch {
-									//pass
-								}
-							}
-						}, 200);
+  registerMonkeyPatches() {
+    const plugin = this;
+    this.register(
+      around(this.app.viewRegistry.constructor.prototype, {
+        registerView(old: any) {
+          return function (
+            type: string,
+            viewCreator: ViewCreator,
+            ...args: unknown[]
+          ) {
+            plugin.app.workspace.trigger("view-registered", type, viewCreator);
+            return old.call(this, type, viewCreator, ...args);
+          };
+        },
+      })
+    );
+    // This catches the initial FE view registration so that we can patch the sort button creation logic before
+    // the button is created
+    // TODO: Add conditional logic to patch the sort button even if we don't catch the initial startup
+    // 1) If layout ready, get the existing FE instance, create a patched button, and hide the existing button
+    // 2) Patch `addSortButton` to emit an event
+    // 3) On event,
+    if (this.app.workspace.layoutReady) {
+      const fileExplorer = this.getFileExplorer();
+      this.patchFileExplorer(fileExplorer);
+    } else {
+      const eventRef = this.app.workspace.on(
+        "view-registered",
+        (type: string, viewCreator: ViewCreator) => {
+          if (type !== "file-explorer") return;
+          this.app.workspace.offref(eventRef);
+          // @ts-ignore we need a leaf before any leafs exists in the workspace, so we create one from scratch
+          const leaf = new WorkspaceLeaf(plugin.app);
+          const fileExplorer = viewCreator(leaf) as FileExplorerView;
+          this.patchFileExplorer(fileExplorer);
+        }
+      );
+    }
+    this.register(
+      around(View.prototype, {
+        onunload(old: any) {
+          return function (...args) {
+            try {
+              if (this.iconSorter) {
+                this.iconSorter.destroy();
+                this.iconSorter = null;
+              }
+            } catch {
+              //pass
+            }
+            return old.call(this, ...args);
+          };
+        },
+        onload(old: any) {
+          return function (...args) {
+            setTimeout(() => {
+              if (this.app.workspace.layoutReady) {
+                try {
+                  if (
+                    !(this.leaf.parentSplit instanceof WorkspaceTabs) &&
+                    this.hasOwnProperty("actionsEl") &&
+                    !this.iconSorter
+                  ) {
+                    this.iconSorter = plugin.setViewActionSorter(
+                      this.actionsEl,
+                      this
+                    );
+                  }
+                } catch {
+                  //pass
+                }
+              }
+            }, 200);
 
-						return old.call(this, ...args);
-					};
-				},
-			})
-		);
-		if (Platform.isDesktop) {
-			this.register(
-				around(HTMLDivElement.prototype, {
-					addEventListener(old: any) {
-						return function (
-							type: string,
-							listener: EventListenerOrEventListenerObject,
-							options?: boolean | AddEventListenerOptions
-						) {
-							if (
-								type === "mousedown" &&
-								listener instanceof Function &&
-								this.hasClass("workspace-tab-header")
-							) {
-								const origListener = listener;
-								listener = (event) => {
-									if (event instanceof MouseEvent && (event?.altKey || event?.metaKey))
-										return;
-									else origListener(event);
-								};
-							}
-							return old.call(this, type, listener, options);
-						};
-					},
-				})
-			);
-		}
-		this.register(
-			around(Workspace.prototype, {
-				splitLeaf(old: any) {
-					return function (
-						source: WorkspaceItem,
-						newLeaf: WorkspaceItem,
-						direction?: SplitDirection,
-						before?: boolean,
-						...args
-					) {
-						const result = old.call(this, source, newLeaf, direction, before, ...args);
-						this.trigger("bartender-leaf-split", source, newLeaf);
-						return result;
-					};
-				},
-				changeLayout(old: any) {
-					return async function (workspace: any, ...args): Promise<void> {
-						const result = await old.call(this, workspace, ...args);
-						this.trigger("bartender-workspace-change");
-						return result;
-					};
-				},
-			})
-		);
-		this.register(
-			around(Plugin.prototype, {
-				addStatusBarItem(old: any) {
-					return function (...args): HTMLElement {
-						const result = old.call(this, ...args);
-						this.app.workspace.trigger("status-bar-updated");
-						return result;
-					};
-				},
-				addRibbonIcon(old: any) {
-					return function (...args): HTMLElement {
-						const result = old.call(this, ...args);
-						this.app.workspace.trigger("ribbon-bar-updated");
-						return result;
-					};
-				},
-			})
-		);
-	}
+            return old.call(this, ...args);
+          };
+        },
+      })
+    );
+    if (Platform.isDesktop) {
+      this.register(
+        around(HTMLDivElement.prototype, {
+          addEventListener(old: any) {
+            return function (
+              type: string,
+              listener: EventListenerOrEventListenerObject,
+              options?: boolean | AddEventListenerOptions
+            ) {
+              if (
+                type === "mousedown" &&
+                listener instanceof Function &&
+                this.hasClass("workspace-tab-header")
+              ) {
+                const origListener = listener;
+                listener = (event) => {
+                  if (
+                    event instanceof MouseEvent &&
+                    (event?.altKey || event?.metaKey)
+                  )
+                    return;
+                  else origListener(event);
+                };
+              }
+              return old.call(this, type, listener, options);
+            };
+          },
+        })
+      );
+    }
+    this.register(
+      around(Workspace.prototype, {
+        splitLeaf(old: any) {
+          return function (
+            source: WorkspaceItem,
+            newLeaf: WorkspaceItem,
+            direction?: SplitDirection,
+            before?: boolean,
+            ...args
+          ) {
+            const result = old.call(
+              this,
+              source,
+              newLeaf,
+              direction,
+              before,
+              ...args
+            );
+            this.trigger("bartender-leaf-split", source, newLeaf);
+            return result;
+          };
+        },
+        changeLayout(old: any) {
+          return async function (workspace: any, ...args): Promise<void> {
+            const result = await old.call(this, workspace, ...args);
+            this.trigger("bartender-workspace-change");
+            return result;
+          };
+        },
+      })
+    );
+    this.register(
+      around(Plugin.prototype, {
+        addStatusBarItem(old: any) {
+          return function (...args): HTMLElement {
+            const result = old.call(this, ...args);
+            this.app.workspace.trigger("status-bar-updated");
+            return result;
+          };
+        },
+        addRibbonIcon(old: any) {
+          return function (...args): HTMLElement {
+            const result = old.call(this, ...args);
+            this.app.workspace.trigger("ribbon-bar-updated");
+            return result;
+          };
+        },
+      })
+    );
+  }
 
-	patchFileExplorer(fileExplorer: FileExplorerView) {
-		const plugin = this;
-		const settings = this.settings;
-		if (!fileExplorer) {
-			return;
-		}
-		const InfinityScroll = fileExplorer.tree.infinityScroll.constructor;
-		// register clear first so that it gets called first onunload
-		this.register(() => this.clearFileExplorerFilter());
-		this.register(
-			around(InfinityScroll.prototype, {
-				compute(old: any) {
-					return function (...args: any[]) {
-						try {
-							if (this.scrollEl.hasClass("nav-files-container")) {
-								plugin.fileExplorerFilter.call(this, fileExplorer);
-							}
-						} catch (err) {
-							console.log(err);
-						}
-						return old.call(this, ...args);
-					};
-				},
-			})
-		);
-		this.register(
-			around(fileExplorer.headerDom.constructor.prototype, {
-				addSortButton(old: any) {
-					return function (...args: any[]) {
-						if (this.navHeaderEl?.parentElement?.dataset?.type === "file-explorer") {
-							plugin.setFileExplorerFilter(this);
-							return addSortButton.call(this, settings, ...args);
-						} else {
-							return old.call(this, ...args);
-						}
-					};
-				},
-			})
-		);
-	}
+  patchFileExplorer(fileExplorer: FileExplorerView) {
+    const plugin = this;
+    const settings = this.settings;
+    if (!fileExplorer) {
+      return;
+    }
+    const InfinityScroll = fileExplorer.tree.infinityScroll.constructor;
+    // register clear first so that it gets called first onunload
+    this.register(() => this.clearFileExplorerFilter());
+    this.register(
+      around(InfinityScroll.prototype, {
+        compute(old: any) {
+          return function (...args: any[]) {
+            try {
+              if (this.scrollEl.hasClass("nav-files-container")) {
+                plugin.fileExplorerFilter.call(this, fileExplorer);
+              }
+            } catch (err) {
+              console.log(err);
+            }
+            return old.call(this, ...args);
+          };
+        },
+      })
+    );
+    this.register(
+      around(fileExplorer.headerDom.constructor.prototype, {
+        addSortButton(old: any) {
+          return function (...args: any[]) {
+            if (
+              this.navHeaderEl?.parentElement?.dataset?.type === "file-explorer"
+            ) {
+              plugin.setFileExplorerFilter(this);
+              return addSortButton.call(this, settings, ...args);
+            } else {
+              return old.call(this, ...args);
+            }
+          };
+        },
+      })
+    );
+  }
 
-	insertSeparator(selector: string, className: string, rtl: Boolean) {
-		const elements = document.body.querySelectorAll(selector);
-		elements.forEach((el: HTMLElement) => {
-			const getSiblings = rtl ? getPreviousSiblings : getNextSiblings;
-			if (!el) {
-				return;
-			}
-			const separator = el.createDiv(`${className} separator`);
-			rtl && el.prepend(separator);
-			const glyphEl = separator.createDiv("glyph");
-			const glyphName = "plus-with-circle"; // this gets replaced using CSS
-			setIcon(glyphEl, glyphName);
-			separator.addClass("is-collapsed");
-			this.register(() => separator.detach());
-			let hideTimeout: NodeJS.Timeout;
-			separator.onClickEvent((event: MouseEvent) => {
-				if (separator.hasClass("is-collapsed")) {
-					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-					separator.removeClass("is-collapsed");
-				} else {
-					getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
-					separator.addClass("is-collapsed");
-				}
-			});
-			el.onmouseenter = (ev) => {
-				if (hideTimeout) clearTimeout(hideTimeout);
-			};
-			el.onmouseleave = (ev) => {
-				if (this.settings.autoHide) {
-					hideTimeout = setTimeout(() => {
-						getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
-						separator.addClass("is-collapsed");
-					}, this.settings.autoHideDelay);
-				}
-			};
-			setTimeout(() => {
-				getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
-				separator.addClass("is-collapsed");
-			}, 0);
-		});
-	}
+  insertSeparator(selector: string, className: string, rtl: boolean) {
+    const elements = document.body.querySelectorAll(selector);
+    elements.forEach((el: HTMLElement) => {
+      const getSiblings = rtl ? getPreviousSiblings : getNextSiblings;
+      if (!el) {
+        return;
+      }
+      const separator = el.createDiv(`${className} separator`);
+      rtl && el.prepend(separator);
+      const glyphEl = separator.createDiv("glyph");
+      const glyphName = "plus-with-circle"; // this gets replaced using CSS
+      setIcon(glyphEl, glyphName);
+      separator.addClass("is-collapsed");
+      this.register(() => separator.detach());
+      let hideTimeout: NodeJS.Timeout;
+      separator.onClickEvent((event: MouseEvent) => {
+        if (separator.hasClass("is-collapsed")) {
+          Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+          separator.removeClass("is-collapsed");
+        } else {
+          getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
+          separator.addClass("is-collapsed");
+        }
+      });
+      el.onmouseenter = (ev) => {
+        if (hideTimeout) clearTimeout(hideTimeout);
+      };
+      el.onmouseleave = (ev) => {
+        if (this.settings.autoHide) {
+          hideTimeout = setTimeout(() => {
+            getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
+            separator.addClass("is-collapsed");
+          }, this.settings.autoHideDelay);
+        }
+      };
+      setTimeout(() => {
+        getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
+        separator.addClass("is-collapsed");
+      }, 0);
+    });
+  }
 
-	setElementIDs(parentEl: HTMLElement, options: GenerateIdOptions) {
-		Array.from(parentEl.children).forEach((child) => {
-			if (child instanceof HTMLElement && !child.getAttribute("data-id")) {
-				child.setAttribute("data-id", generateId(child, options));
-			}
-		});
-	}
+  setElementIDs(parentEl: HTMLElement, options: GenerateIdOptions) {
+    Array.from(parentEl.children).forEach((child) => {
+      if (child instanceof HTMLElement && !child.getAttribute("data-id")) {
+        child.setAttribute("data-id", generateId(child, options));
+      }
+    });
+  }
 
-	setTabBarSorter(element: HTMLElement, leaf: WorkspaceTabs) {
-		this.setElementIDs(element, { useClass: true, useIcon: true });
-		return Sortable.create(element, {
-			group: "leftTabBar",
-			dataIdAttr: "data-id",
-			chosenClass: "bt-sortable-chosen",
-			delay: Platform.isMobile ? 200 : this.settings.dragDelay,
-			dropBubble: false,
-			dragoverBubble: false,
-			animation: ANIMATION_DURATION,
-			onChoose: () => element.parentElement?.addClass("is-dragging"),
-			onUnchoose: () => element.parentElement?.removeClass("is-dragging"),
-			onStart: () => {
-				document.body.addClass("is-dragging");
-				element.querySelector(".separator")?.removeClass("is-collapsed");
-				Array.from(element.children).forEach((el) => el.removeClass("is-hidden"));
-			},
-			onEnd: (event) => {
-				document.body.removeClass("is-dragging");
-				if (event.oldIndex !== undefined && event.newIndex !== undefined) {
-					reorderArray(leaf.children, event.oldIndex, event.newIndex);
-					leaf.currentTab = event.newIndex;
-					leaf.recomputeChildrenDimensions();
-				}
-				this.app.workspace.requestSaveLayout();
-			},
-		});
-	}
+  setTabBarSorter(element: HTMLElement, leaf: WorkspaceTabs) {
+    this.setElementIDs(element, { useClass: true, useIcon: true });
+    return Sortable.create(element, {
+      group: "leftTabBar",
+      dataIdAttr: "data-id",
+      chosenClass: "bt-sortable-chosen",
+      delay: Platform.isMobile ? 200 : this.settings.dragDelay,
+      dropBubble: false,
+      dragoverBubble: false,
+      animation: ANIMATION_DURATION,
+      onChoose: () => element.parentElement?.addClass("is-dragging"),
+      onUnchoose: () => element.parentElement?.removeClass("is-dragging"),
+      onStart: () => {
+        document.body.addClass("is-dragging");
+        element.querySelector(".separator")?.removeClass("is-collapsed");
+        Array.from(element.children).forEach((el) =>
+          el.removeClass("is-hidden")
+        );
+      },
+      onEnd: (event) => {
+        document.body.removeClass("is-dragging");
+        if (event.oldIndex !== undefined && event.newIndex !== undefined) {
+          reorderArray(leaf.children, event.oldIndex, event.newIndex);
+          leaf.currentTab = event.newIndex;
+          leaf.recomputeChildrenDimensions();
+        }
+        this.app.workspace.requestSaveLayout();
+      },
+    });
+  }
 
-	setStatusBarSorter() {
-		const el = document.body.querySelector(
-			"body > div.app-container > div.status-bar"
-		) as HTMLElement;
-		if (el) {
-			this.setElementIDs(el, { useClass: true, useAria: true, useIcon: true });
-			this.statusBarSorter = Sortable.create(el, {
-				group: "statusBar",
-				dataIdAttr: "data-id",
-				chosenClass: "bt-sortable-chosen",
-				delay: Platform.isMobile ? 200 : this.settings.dragDelay,
-				animation: ANIMATION_DURATION,
-				onChoose: () => {
-					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-				},
-				onStart: () => {
-					el.querySelector(".separator")?.removeClass("is-collapsed");
-					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-				},
-				store: {
-					get: (sortable) => {
-						return this.settings.statusBarOrder;
-					},
-					set: (s) => {
-						this.settings.statusBarOrder = s.toArray();
-						this.saveSettings();
-					},
-				},
-			});
-		}
-	}
+  setStatusBarSorter() {
+    const el = document.body.querySelector(
+      "body > div.app-container > div.status-bar"
+    ) as HTMLElement;
+    if (el) {
+      this.setElementIDs(el, { useClass: true, useAria: true, useIcon: true });
+      this.statusBarSorter = Sortable.create(el, {
+        group: "statusBar",
+        dataIdAttr: "data-id",
+        chosenClass: "bt-sortable-chosen",
+        delay: Platform.isMobile ? 200 : this.settings.dragDelay,
+        animation: ANIMATION_DURATION,
+        onChoose: () => {
+          Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+        },
+        onStart: () => {
+          el.querySelector(".separator")?.removeClass("is-collapsed");
+          Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+        },
+        store: {
+          get: (sortable) => {
+            return this.settings.statusBarOrder;
+          },
+          set: (s) => {
+            this.settings.statusBarOrder = s.toArray();
+            this.saveSettings();
+          },
+        },
+      });
+    }
+  }
 
-	setViewActionSorter(el: HTMLElement, view: View): Sortable | undefined {
-		this.setElementIDs(el, { useClass: true, useIcon: true });
-		const hasSorter = Object.values(el).find((value) =>
-			value?.hasOwnProperty("nativeDraggable")
-		);
-		if (hasSorter) return undefined;
-		const viewType = view?.getViewType() || "unknown";
-		return new Sortable(el, {
-			group: "actionBar",
-			dataIdAttr: "data-id",
-			chosenClass: "bt-sortable-chosen",
-			delay: Platform.isMobile ? 200 : this.settings.dragDelay,
-			sort: true,
-			animation: ANIMATION_DURATION,
-			onStart: () => {
-				el.querySelector(".separator")?.removeClass("is-collapsed");
-				Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-			},
-			store: {
-				get: () => {
-					return this.settings.actionBarOrder[viewType];
-				},
-				set: (s) => {
-					this.settings.actionBarOrder[viewType] = s.toArray();
-					this.saveSettings();
-				},
-			},
-		});
-	}
+  setViewActionSorter(el: HTMLElement, view: View): Sortable | undefined {
+    this.setElementIDs(el, { useClass: true, useIcon: true });
+    const hasSorter = Object.values(el).find((value) =>
+      value?.hasOwnProperty("nativeDraggable")
+    );
+    if (hasSorter) return undefined;
+    const viewType = view?.getViewType() || "unknown";
+    return new Sortable(el, {
+      group: "actionBar",
+      dataIdAttr: "data-id",
+      chosenClass: "bt-sortable-chosen",
+      delay: Platform.isMobile ? 200 : this.settings.dragDelay,
+      sort: true,
+      animation: ANIMATION_DURATION,
+      onStart: () => {
+        el.querySelector(".separator")?.removeClass("is-collapsed");
+        Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+      },
+      store: {
+        get: () => {
+          return this.settings.actionBarOrder[viewType];
+        },
+        set: (s) => {
+          this.settings.actionBarOrder[viewType] = s.toArray();
+          this.saveSettings();
+        },
+      },
+    });
+  }
 
-	setRibbonBarSorter() {
-		const el = document.body.querySelector(
-			"body > div.app-container div.side-dock-actions"
-		) as HTMLElement;
-		if (el) {
-			this.setElementIDs(el, { useClass: true, useAria: true, useIcon: true });
-			this.ribbonBarSorter = Sortable.create(el, {
-				group: "ribbonBar",
-				dataIdAttr: "data-id",
-				delay: Platform.isMobile ? 200 : this.settings.dragDelay,
-				chosenClass: "bt-sortable-chosen",
-				animation: ANIMATION_DURATION,
-				onChoose: () => {
-					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-				},
-				onStart: () => {
-					el.querySelector(".separator")?.removeClass("is-collapsed");
-					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-				},
-				store: {
-					get: (sortable) => {
-						return this.settings.ribbonBarOrder;
-					},
-					set: (s) => {
-						this.settings.ribbonBarOrder = s.toArray();
-						this.saveSettings();
-					},
-				},
-			});
-		}
-	}
+  setRibbonBarSorter() {
+    const el = document.body.querySelector(
+      "body > div.app-container div.side-dock-actions"
+    ) as HTMLElement;
+    if (el) {
+      this.setElementIDs(el, { useClass: true, useAria: true, useIcon: true });
+      this.ribbonBarSorter = Sortable.create(el, {
+        group: "ribbonBar",
+        dataIdAttr: "data-id",
+        delay: Platform.isMobile ? 200 : this.settings.dragDelay,
+        chosenClass: "bt-sortable-chosen",
+        animation: ANIMATION_DURATION,
+        onChoose: () => {
+          Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+        },
+        onStart: () => {
+          el.querySelector(".separator")?.removeClass("is-collapsed");
+          Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+        },
+        store: {
+          get: (sortable) => {
+            return this.settings.ribbonBarOrder;
+          },
+          set: (s) => {
+            this.settings.ribbonBarOrder = s.toArray();
+            this.saveSettings();
+          },
+        },
+      });
+    }
+  }
 
-	setFileExplorerFilter(headerDom: FileExplorerHeader) {
-		const fileExplorerNav = headerDom.navHeaderEl;
-		if (!fileExplorerNav) {
-			return;
-		}
-		const fileExplorerFilter = fileExplorerNav.createDiv("search-input-container");
-		fileExplorerNav.insertAdjacentElement("afterend", fileExplorerFilter);
-		const fileExplorerFilterInput = fileExplorerFilter.createEl("input");
-		fileExplorerFilterInput.placeholder = "Type to filter...";
-		fileExplorerFilterInput.type = "text";
-		fileExplorerFilter.hide();
-		const filterScope = new Scope(this.app.scope);
-		fileExplorerFilterInput.onfocus = () => {
-			this.app.keymap.pushScope(filterScope);
-		};
-		fileExplorerFilterInput.onblur = () => {
-			this.app.keymap.popScope(filterScope);
-		};
-		fileExplorerFilterInput.oninput = (ev: InputEvent) => {
-			const fileExplorer = this.getFileExplorer();
-			if (ev.target instanceof HTMLInputElement) {
-				if (ev.target.value.length) {
-					clearButtonEl.show();
-				} else {
-					clearButtonEl.hide();
-				}
-				fileExplorer.tree.infinityScroll.filter = ev.target.value;
-			}
-			fileExplorer.tree.infinityScroll.compute();
-		};
-		const clearButtonEl = fileExplorerFilter.createDiv(
-			"search-input-clear-button",
-			(el) => {
-				el.addEventListener("click", () => {
-					(fileExplorerFilterInput.value = ""), clearButtonEl.hide();
-					fileExplorerFilterInput.focus();
-					fileExplorerFilterInput.dispatchEvent(new Event("input"));
-				}),
-					el.hide();
-			}
-		);
-	}
+  setFileExplorerFilter(headerDom: FileExplorerHeader) {
+    const fileExplorerNav = headerDom.navHeaderEl;
+    if (!fileExplorerNav) {
+      return;
+    }
+    const fileExplorerFilter = fileExplorerNav.createDiv(
+      "search-input-container"
+    );
+    fileExplorerNav.insertAdjacentElement("afterend", fileExplorerFilter);
+    const fileExplorerFilterInput = fileExplorerFilter.createEl("input");
+    fileExplorerFilterInput.placeholder = "Type to filter...";
+    fileExplorerFilterInput.type = "text";
+    fileExplorerFilter.hide();
+    const filterScope = new Scope(this.app.scope);
+    fileExplorerFilterInput.onfocus = () => {
+      this.app.keymap.pushScope(filterScope);
+    };
+    fileExplorerFilterInput.onblur = () => {
+      this.app.keymap.popScope(filterScope);
+    };
+    fileExplorerFilterInput.oninput = (ev: InputEvent) => {
+      const fileExplorer = this.getFileExplorer();
+      if (ev.target instanceof HTMLInputElement) {
+        if (ev.target.value.length) {
+          clearButtonEl.show();
+        } else {
+          clearButtonEl.hide();
+        }
+        fileExplorer.tree.infinityScroll.filter = ev.target.value;
+      }
+      fileExplorer.tree.infinityScroll.compute();
+    };
+    const clearButtonEl = fileExplorerFilter.createDiv(
+      "search-input-clear-button",
+      (el) => {
+        el.addEventListener("click", () => {
+          (fileExplorerFilterInput.value = ""), clearButtonEl.hide();
+          fileExplorerFilterInput.focus();
+          fileExplorerFilterInput.dispatchEvent(new Event("input"));
+        }),
+          el.hide();
+      }
+    );
+  }
 
-	setFileExplorerSorter(fileExplorer?: FileExplorerView) {
-		// TODO: Register sorter on new folder creation
-		// TODO: Unregister sorter on folder deletion
-		if (!fileExplorer) fileExplorer = this.getFileExplorer();
-		if (
-			!fileExplorer ||
-			this.settings.sortOrder !== "custom" ||
-			fileExplorer.hasCustomSorter
-		)
-			return;
-		const roots = this.getRootFolders(fileExplorer);
-		if (!roots || !roots.length) return;
-		for (const root of roots) {
-			const el = root?.childrenEl;
-			if (!el) continue;
-			let draggedItems: HTMLElement[];
-			fileExplorer.hasCustomSorter = true;
-			const dragEnabled = document.body
-				.querySelector("div.nav-action-button.drag-to-rearrange")
-				?.hasClass("is-active")
-				? true
-				: false;
-			const path = root.file?.path ?? "";
+  setFileExplorerSorter(fileExplorer?: FileExplorerView) {
+    // TODO: Register sorter on new folder creation
+    // TODO: Unregister sorter on folder deletion
+    if (!fileExplorer) fileExplorer = this.getFileExplorer();
+    if (
+      !fileExplorer ||
+      this.settings.sortOrder !== "custom" ||
+      fileExplorer.hasCustomSorter
+    )
+      return;
+    const roots = this.getRootFolders(fileExplorer);
+    if (!roots || !roots.length) return;
+    for (const root of roots) {
+      const el = root?.childrenEl;
+      if (!el) continue;
+      let draggedItems: HTMLElement[];
+      fileExplorer.hasCustomSorter = true;
+      const dragEnabled = document.body
+        .querySelector("div.nav-action-button.drag-to-rearrange")
+        ?.hasClass("is-active")
+        ? true
+        : false;
+      const path = root.file?.path ?? "";
 
-			root.sorter = Sortable.create(el!, {
-				group: `fileExplorer${path}`,
-				forceFallback: true,
-				multiDrag: true,
-				// @ts-ignore
-				multiDragKey: "alt",
-				// selectedClass: "is-selected",
-				chosenClass: "bt-sortable-chosen",
-				delay: 0,
-				disabled: !dragEnabled,
-				sort: dragEnabled, // init with dragging disabled. the nav bar button will toggle on/off
-				animation: ANIMATION_DURATION,
-				onStart: (evt) => {
-					draggedItems = evt.items.length ? evt.items : [evt.item];
-				},
-				onMove: (evt) => {
-					// TODO: Refactor this
-					// Responsible for updating the internal Obsidian array that contains the file item order
-					// Without this logic, reordering is ephemeral and will be undone by Obisidian's native processes
-					const supportsVirtualChildren = requireApiVersion?.("0.15.0");
-					let _children = supportsVirtualChildren
-						? root.vChildren?._children
-						: root.children;
-					if (!_children || !draggedItems?.length) return;
-					let children = _children.map((child) => child.el);
-					const adjacentEl = evt.related;
-					const targetIndex = children.indexOf(adjacentEl);
-					const firstItem = draggedItems.first();
-					const firstItemIndex = children.indexOf(firstItem!);
-					const _draggedItems = draggedItems.slice();
-					if (firstItemIndex > targetIndex) _draggedItems.reverse();
-					for (const item of _draggedItems) {
-						const itemIndex = children.indexOf(item);
-						_children = reorderArray(_children, itemIndex, targetIndex);
-						children = reorderArray(children, itemIndex, targetIndex);
-					}
-					this.settings.fileExplorerOrder[path] = _children.map(
-						(child) => child.file.path
-					);
-					this.saveSettings();
-					// return !adjacentEl.hasClass("nav-folder");
-				},
-				onEnd: (_evt) => {
-					draggedItems = [];
-					document.querySelector("body>div.drag-ghost")?.detach();
-				},
-			});
-		}
-	}
+      root.sorter = Sortable.create(el!, {
+        group: `fileExplorer${path}`,
+        forceFallback: true,
+        multiDrag: true,
+        // @ts-ignore
+        multiDragKey: "alt",
+        // selectedClass: "is-selected",
+        chosenClass: "bt-sortable-chosen",
+        delay: 0,
+        disabled: !dragEnabled,
+        sort: dragEnabled, // init with dragging disabled. the nav bar button will toggle on/off
+        animation: ANIMATION_DURATION,
+        onStart: (evt) => {
+          draggedItems = evt.items.length ? evt.items : [evt.item];
+        },
+        onMove: (evt) => {
+          // TODO: Refactor this
+          // Responsible for updating the internal Obsidian array that contains the file item order
+          // Without this logic, reordering is ephemeral and will be undone by Obisidian's native processes
+          const supportsVirtualChildren = requireApiVersion?.("0.15.0");
+          let _children = supportsVirtualChildren
+            ? root.vChildren?._children
+            : root.children;
+          if (!_children || !draggedItems?.length) return;
+          let children = _children.map((child) => child.el);
+          const adjacentEl = evt.related;
+          const targetIndex = children.indexOf(adjacentEl);
+          const firstItem = draggedItems.first();
+          const firstItemIndex = children.indexOf(firstItem!);
+          const _draggedItems = draggedItems.slice();
+          if (firstItemIndex > targetIndex) _draggedItems.reverse();
+          for (const item of _draggedItems) {
+            const itemIndex = children.indexOf(item);
+            _children = reorderArray(_children, itemIndex, targetIndex);
+            children = reorderArray(children, itemIndex, targetIndex);
+          }
+          this.settings.fileExplorerOrder[path] = _children.map(
+            (child) => child.file.path
+          );
+          this.saveSettings();
+          // return !adjacentEl.hasClass("nav-folder");
+        },
+        onEnd: (_evt) => {
+          draggedItems = [];
+          document.querySelector("body>div.drag-ghost")?.detach();
+        },
+      });
+    }
+  }
 
-	getFileExplorer() {
-		const fileExplorer: FileExplorerView | undefined = this.app.workspace
-			.getLeavesOfType("file-explorer")
-			?.first()?.view as unknown as FileExplorerView;
-		return fileExplorer;
-	}
+  getFileExplorer() {
+    const fileExplorer: FileExplorerView | undefined = this.app.workspace
+      .getLeavesOfType("file-explorer")
+      ?.first()?.view as unknown as FileExplorerView;
+    return fileExplorer;
+  }
 
-	getRootFolders(
-		fileExplorer?: FileExplorerView
-	): [RootElements | ChildElement] | undefined {
-		if (!fileExplorer) fileExplorer = this.getFileExplorer();
-		if (!fileExplorer) return;
-		const root = fileExplorer.tree?.infinityScroll?.rootEl;
-		return root && this.traverseRoots(root);
-	}
+  getRootFolders(
+    fileExplorer?: FileExplorerView
+  ): [RootElements | ChildElement] | undefined {
+    if (!fileExplorer) fileExplorer = this.getFileExplorer();
+    if (!fileExplorer) return;
+    const root = fileExplorer.tree?.infinityScroll?.rootEl;
+    return root && this.traverseRoots(root);
+  }
 
-	traverseRoots(
-		root: RootElements | ChildElement,
-		items?: [RootElements | ChildElement]
-	) {
-		if (!items) items = [root];
-		const supportsVirtualChildren = requireApiVersion?.("0.15.0");
-		const _children = supportsVirtualChildren ? root.vChildren?._children : root.children;
-		for (const child of _children || []) {
-			if (child.children || child.vChildren?._children) {
-				items.push(child);
-			}
-			this.traverseRoots(child, items);
-		}
-		return items;
-	}
+  traverseRoots(
+    root: RootElements | ChildElement,
+    items?: [RootElements | ChildElement]
+  ) {
+    if (!items) items = [root];
+    const supportsVirtualChildren = requireApiVersion?.("0.15.0");
+    const _children = supportsVirtualChildren
+      ? root.vChildren?._children
+      : root.children;
+    for (const child of _children || []) {
+      if (child.children || child.vChildren?._children) {
+        items.push(child);
+      }
+      this.traverseRoots(child, items);
+    }
+    return items;
+  }
 
-	toggleFileExplorerSorters(enable: boolean) {
-		const fileExplorer = this.getFileExplorer();
-		const roots = this.getRootFolders(fileExplorer);
-		if (roots?.length) {
-			for (const root of roots) {
-				if (root.sorter) {
-					root.sorter.option("sort", enable);
-					root.sorter.option("disabled", !enable);
-				}
-			}
-		}
-	}
+  toggleFileExplorerSorters(enable: boolean) {
+    const fileExplorer = this.getFileExplorer();
+    const roots = this.getRootFolders(fileExplorer);
+    if (roots?.length) {
+      for (const root of roots) {
+        if (root.sorter) {
+          root.sorter.option("sort", enable);
+          root.sorter.option("disabled", !enable);
+        }
+      }
+    }
+  }
 
-	cleanupFileExplorerSorters() {
-		const fileExplorer = this.getFileExplorer();
-		const roots = this.getRootFolders(fileExplorer);
-		if (roots?.length) {
-			for (const root of roots) {
-				if (root.sorter) {
-					root.sorter.destroy();
-					delete root.sorter;
-					Object.keys(root.childrenEl!).forEach(
-						(key) => key.startsWith("Sortable") && delete (root.childrenEl as any)[key]
-					);
-					// sortable.destroy removes all of the draggble attributes :( so we put them back
-					root
-						.childrenEl!.querySelectorAll("div.nav-file-title")
-						.forEach((el: HTMLDivElement) => (el.draggable = true));
-					root
-						.childrenEl!.querySelectorAll("div.nav-folder-title")
-						.forEach((el: HTMLDivElement) => (el.draggable = true));
-				}
-			}
-		}
-		delete fileExplorer.hasCustomSorter;
-		// unset "custom" file explorer sort
-		if (this.app.vault.getConfig("fileSortOrder") === "custom") {
-			fileExplorer.setSortOrder("alphabetical");
-		}
-	}
+  cleanupFileExplorerSorters() {
+    const fileExplorer = this.getFileExplorer();
+    const roots = this.getRootFolders(fileExplorer);
+    if (roots?.length) {
+      for (const root of roots) {
+        if (root.sorter) {
+          root.sorter.destroy();
+          delete root.sorter;
+          Object.keys(root.childrenEl!).forEach(
+            (key) =>
+              key.startsWith("Sortable") && delete (root.childrenEl as any)[key]
+          );
+          // sortable.destroy removes all of the draggble attributes :( so we put them back
+          root
+            .childrenEl!.querySelectorAll("div.nav-file-title")
+            .forEach((el: HTMLDivElement) => (el.draggable = true));
+          root
+            .childrenEl!.querySelectorAll("div.nav-folder-title")
+            .forEach((el: HTMLDivElement) => (el.draggable = true));
+        }
+      }
+    }
+    delete fileExplorer.hasCustomSorter;
+    // unset "custom" file explorer sort
+    if (this.app.vault.getConfig("fileSortOrder") === "custom") {
+      fileExplorer.setSortOrder("alphabetical");
+    }
+  }
 
-	onunload(): void {
-		this.statusBarSorter?.destroy();
-		this.ribbonBarSorter?.destroy();
-		this.app.workspace.iterateAllLeaves((leaf) => {
-			let sorterParent: View | WorkspaceTabs | WorkspaceLeaf | boolean;
-			if (
-				(sorterParent = leaf?.iconSorter ? leaf : false) ||
-				(sorterParent = leaf?.view?.iconSorter ? leaf.view : false) ||
-				(sorterParent =
-					leaf?.parentSplit instanceof WorkspaceTabs && leaf?.parentSplit?.iconSorter
-						? leaf?.parentSplit
-						: false)
-			) {
-				try {
-					sorterParent.iconSorter?.destroy();
-				} finally {
-					delete sorterParent.iconSorter;
-				}
-			}
-		});
+  onunload(): void {
+    this.statusBarSorter?.destroy();
+    this.ribbonBarSorter?.destroy();
+    this.app.workspace.iterateAllLeaves((leaf) => {
+      let sorterParent: View | WorkspaceTabs | WorkspaceLeaf | boolean;
+      if (
+        (sorterParent = leaf?.iconSorter ? leaf : false) ||
+        (sorterParent = leaf?.view?.iconSorter ? leaf.view : false) ||
+        (sorterParent =
+          leaf?.parentSplit instanceof WorkspaceTabs &&
+          leaf?.parentSplit?.iconSorter
+            ? leaf?.parentSplit
+            : false)
+      ) {
+        try {
+          sorterParent.iconSorter?.destroy();
+        } finally {
+          delete sorterParent.iconSorter;
+        }
+      }
+    });
 
-		// clean up file explorer sorters
-		this.cleanupFileExplorerSorters();
-	}
+    // clean up file explorer sorters
+    this.cleanupFileExplorerSorters();
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,39 +1,37 @@
 import Fuse from "fuse.js";
 import { around } from "monkey-around";
 import {
-  ChildElement,
-  FileExplorerHeader,
-  FileExplorerView,
-  Platform,
-  Plugin,
-  RootElements,
-  Scope,
-  setIcon,
-  SplitDirection,
-  TFolder,
-  Vault,
-  View,
-  ViewCreator,
-  Workspace,
-  WorkspaceItem,
-  WorkspaceLeaf,
-  WorkspaceSplit,
-  WorkspaceTabs,
-  requireApiVersion,
+	type ChildElement,
+	type FileExplorerHeader,
+	type FileExplorerView,
+	Platform,
+	Plugin,
+	type RootElements,
+	Scope,
+	setIcon,
+	type SplitDirection,
+	View,
+	type ViewCreator,
+	Workspace,
+	type WorkspaceItem,
+	WorkspaceLeaf,
+	type WorkspaceSplit,
+	WorkspaceTabs,
+	requireApiVersion,
 } from "obsidian";
 
 import Sortable, { MultiDrag } from "sortablejs";
 import { addSortButton, folderSortV2 } from "./file-explorer/custom-sort";
 import { type BartenderSettings, DEFAULT_SETTINGS, SettingTab } from "./settings/settings";
 import {
-  generateId,
-  GenerateIdOptions,
-  getFn,
-  getItems,
-  getNextSiblings,
-  getPreviousSiblings,
-  highlight,
-  reorderArray,
+	generateId,
+	type GenerateIdOptions,
+	getFn,
+	getItems,
+	getNextSiblings,
+	getPreviousSiblings,
+	highlight,
+	reorderArray,
 } from "./utils";
 
 Sortable.mount(new MultiDrag());
@@ -43,19 +41,19 @@ const RIBBON_BAR_SELECTOR = "body > div.app-container div.side-dock-actions";
 const ANIMATION_DURATION = 500;
 
 export default class BartenderPlugin extends Plugin {
-  statusBarSorter: Sortable;
-  ribbonBarSorter: Sortable;
-  fileSorter: Sortable;
-  separator: HTMLElement;
-  settings: BartenderSettings;
-  settingsTab: SettingTab;
+	statusBarSorter: Sortable;
+	ribbonBarSorter: Sortable;
+	fileSorter: Sortable;
+	separator: HTMLElement;
+	settings: BartenderSettings;
+	settingsTab: SettingTab;
 
-  async onload() {
-    await this.loadSettings();
-    this.registerMonkeyPatches();
-    this.registerEventHandlers();
-    this.registerSettingsTab();
-    this.initialize();
+	async onload() {
+		await this.loadSettings();
+		this.registerMonkeyPatches();
+		this.registerEventHandlers();
+		this.registerSettingsTab();
+		this.initialize();
 
 		this.app.vault.on("rename", async (file, oldFile) => {
 			// change the path in the settings
@@ -94,842 +92,803 @@ export default class BartenderPlugin extends Plugin {
 			}
 			await this.saveSettings();
 		});
-  }
+	}
 
-  async loadSettings() {
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-  }
+	async loadSettings() {
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+	}
 
-  async saveSettings() {
-    await this.saveData(this.settings);
-  }
+	async saveSettings() {
+		await this.saveData(this.settings);
+	}
 
-  patchFileExplorerFolder() {
-    const plugin = this;
-    const leaf = plugin.app.workspace.getLeaf(true);
-    const fileExplorer = plugin.app.viewRegistry.viewByType["file-explorer"](
-      leaf
-    ) as FileExplorerView;
-    this.register(
+	patchFileExplorerFolder() {
+		const plugin = this;
+		const leaf = plugin.app.workspace.getLeaf(true);
+		const fileExplorer = plugin.app.viewRegistry.viewByType["file-explorer"](
+			leaf
+		) as FileExplorerView;
+		this.register(
 			around(fileExplorer.constructor.prototype, {
 				getSortedFolderItems: (old: any) => {
-          return function (...args: any[]) {
+					return function (...args: any[]) {
 						if (plugin.settings.sortOrder === "custom") {
 							return folderSortV2.call(this, plugin.settings, ...args);
 						}
 						return old.call(this, ...args);
-          };
-        },
-      })
-    );
+					};
+				},
+			})
+		);
 
-    leaf.detach();
-  }
+		leaf.detach();
+	}
 
-  initialize() {
-    this.app.workspace.onLayoutReady(() => {
-      this.patchFileExplorerFolder();
-      setTimeout(
-        () => {
-          if (Platform.isDesktop) {
-            // add sorter to the status bar
-            this.insertSeparator(STATUS_BAR_SELECTOR, "status-bar-item", true);
-            this.setStatusBarSorter();
+	initialize() {
+		this.app.workspace.onLayoutReady(() => {
+			this.patchFileExplorerFolder();
+			setTimeout(
+				() => {
+					if (Platform.isDesktop && this.settings.useCollapse) {
+						// add sorter to the status bar
+						this.insertSeparator(STATUS_BAR_SELECTOR, "status-bar-item", true);
+						this.setStatusBarSorter();
 
-            // add sorter to the sidebar tabs
-            if (requireApiVersion && !requireApiVersion("0.15.3")) {
-              const left = (this.app.workspace.leftSplit as WorkspaceSplit)
-                .children;
-              const right = (this.app.workspace.rightSplit as WorkspaceSplit)
-                .children;
-              left.concat(right).forEach((child) => {
-                if (child.hasOwnProperty("tabsInnerEl") && !child.iconSorter) {
-                  child.iconSorter = this.setTabBarSorter(
-                    child.tabsInnerEl,
-                    child
-                  );
-                }
-              });
-            }
-          }
+						// add sorter to the sidebar tabs
+						if (requireApiVersion && !requireApiVersion("0.15.3")) {
+							const left = (this.app.workspace.leftSplit as WorkspaceSplit).children;
+							const right = (this.app.workspace.rightSplit as WorkspaceSplit).children;
+							left.concat(right).forEach((child) => {
+								if (child.hasOwnProperty("tabsInnerEl") && !child.iconSorter) {
+									child.iconSorter = this.setTabBarSorter(child.tabsInnerEl, child);
+								}
+							});
+						}
+					}
 
-          // add file explorer sorter
-          this.setFileExplorerSorter();
+					// add file explorer sorter
+					this.setFileExplorerSorter();
 
-          // add sorter to the left sidebar ribbon
-          this.insertSeparator(
-            RIBBON_BAR_SELECTOR,
-            "side-dock-ribbon-action",
-            false
-          );
-          this.setRibbonBarSorter();
+					// add sorter to the left sidebar ribbon
+					if (this.settings.useCollapse) {
+						this.insertSeparator(RIBBON_BAR_SELECTOR, "side-dock-ribbon-action", false);
+						this.setRibbonBarSorter();
+					}
 
-          // add sorter to all view actions icon groups
-          this.app.workspace.iterateRootLeaves((leaf) => {
-            if (
-              leaf?.view?.hasOwnProperty("actionsEl") &&
-              !leaf?.view?.hasOwnProperty("iconSorter")
-            ) {
-              leaf.view.iconSorter = this.setViewActionSorter(
-                leaf.view.actionsEl,
-                leaf.view
-              );
-            }
-          });
-        },
-        Platform.isMobile ? 3000 : 400
-      ); // give time for plugins like Customizable Page Header to add their icons
-    });
-  }
+					// add sorter to all view actions icon groups
+					this.app.workspace.iterateRootLeaves((leaf) => {
+						if (
+							leaf?.view?.hasOwnProperty("actionsEl") &&
+							!leaf?.view?.hasOwnProperty("iconSorter")
+						) {
+							leaf.view.iconSorter = this.setViewActionSorter(
+								leaf.view.actionsEl,
+								leaf.view
+							);
+						}
+					});
+				},
+				Platform.isMobile ? 3000 : 400
+			); // give time for plugins like Customizable Page Header to add their icons
+		});
+	}
 
-  registerSettingsTab() {
-    this.settingsTab = new SettingTab(this.app, this);
-    this.addSettingTab(this.settingsTab);
-  }
+	registerSettingsTab() {
+		this.settingsTab = new SettingTab(this.app, this);
+		this.addSettingTab(this.settingsTab);
+	}
 
-  clearFileExplorerFilter() {
-    const fileExplorer = this.getFileExplorer();
-    const fileExplorerFilterEl: HTMLInputElement | null =
-      document.body.querySelector(
-        '.workspace-leaf-content[data-type="file-explorer"] .search-input-container > input'
-      );
-    if (fileExplorerFilterEl) fileExplorerFilterEl.value = "";
-    fileExplorer.tree.infinityScroll.filter = "";
-    fileExplorer.tree.infinityScroll.compute();
-  }
+	clearFileExplorerFilter() {
+		const fileExplorer = this.getFileExplorer();
+		const fileExplorerFilterEl: HTMLInputElement | null = document.body.querySelector(
+			'.workspace-leaf-content[data-type="file-explorer"] .search-input-container > input'
+		);
+		if (fileExplorerFilterEl) fileExplorerFilterEl.value = "";
+		fileExplorer.tree.infinityScroll.filter = "";
+		fileExplorer.tree.infinityScroll.compute();
+	}
 
-  fileExplorerFilter = function (fileExplorer: FileExplorerView) {
-    const supportsVirtualChildren = requireApiVersion?.("0.15.0");
-    /*    let leaf = this?.rootEl?.view?.app.workspace.getLeaf(true);
+	fileExplorerFilter = function (fileExplorer: FileExplorerView) {
+		const supportsVirtualChildren = requireApiVersion?.("0.15.0");
+		/*    let leaf = this?.rootEl?.view?.app.workspace.getLeaf(true);
     let fileExplorer = this?.rootEl?.view?.app.viewRegistry.viewByType["file-explorer"](leaf) as FileExplorerView;*/
 
-    //let fileExplorer = this?.rootEl?.fileExplorer;
+		//let fileExplorer = this?.rootEl?.fileExplorer;
 
-    if (!fileExplorer) return;
-    const _children = supportsVirtualChildren
-      ? this.rootEl?.vChildren._children
-      : this.rootEl?.children;
-    if (!_children) return;
-    if (this.filter?.length >= 1) {
-      if (!this.filtered) {
-        this.rootEl._children = _children;
-        this.filtered = true;
-      }
-      const options = {
-        includeScore: true,
-        includeMatches: true,
-        useExtendedSearch: true,
-        getFn,
-        threshold: 0.1,
-        ignoreLocation: true,
-        keys: ["file.path"],
-      };
-      const flattenedItems = getItems(this.rootEl._children);
-      const fuse = new Fuse(flattenedItems, options);
-      const maxResults = 200;
-      const results = fuse.search(this.filter).slice(0, maxResults);
-      if (supportsVirtualChildren) {
-        this.rootEl.vChildren._children = highlight(results);
-      } else {
-        this.rootEl.children = highlight(results);
-      }
-      return;
-    }
-    if (!(this.filter?.length < 1 && this.filtered)) {
-      return;
-    }
-    if (this.rootEl._children) {
-      if (supportsVirtualChildren) {
-        this.rootEl.vChildren._children = this.rootEl._children;
-      } else {
-        this.rootEl.children = this.rootEl._children;
-      }
-    }
+		if (!fileExplorer) return;
+		const _children = supportsVirtualChildren
+			? this.rootEl?.vChildren._children
+			: this.rootEl?.children;
+		if (!_children) return;
+		if (this.filter?.length >= 1) {
+			if (!this.filtered) {
+				this.rootEl._children = _children;
+				this.filtered = true;
+			}
+			const options = {
+				includeScore: true,
+				includeMatches: true,
+				useExtendedSearch: true,
+				getFn,
+				threshold: 0.1,
+				ignoreLocation: true,
+				keys: ["file.path"],
+			};
+			const flattenedItems = getItems(this.rootEl._children);
+			const fuse = new Fuse(flattenedItems, options);
+			const maxResults = 200;
+			const results = fuse.search(this.filter).slice(0, maxResults);
+			if (supportsVirtualChildren) {
+				this.rootEl.vChildren._children = highlight(results);
+			} else {
+				this.rootEl.children = highlight(results);
+			}
+			return;
+		}
+		if (!(this.filter?.length < 1 && this.filtered)) {
+			return;
+		}
+		if (this.rootEl._children) {
+			if (supportsVirtualChildren) {
+				this.rootEl.vChildren._children = this.rootEl._children;
+			} else {
+				this.rootEl.children = this.rootEl._children;
+			}
+		}
 
-    const flattenedItems = getItems(this.rootEl._children);
-    flattenedItems.map((match: ChildElement) => {
-      if (!(<any>match).innerEl.origContent) {
-        return;
-      }
-      // @ts-ignore
-      match.innerEl.setText((<any>match).innerEl.origContent);
-      delete (<any>match).innerEl.origContent;
-      // @ts-ignore
-      match.innerEl.removeClass("has-matches");
-    });
+		const flattenedItems = getItems(this.rootEl._children);
+		flattenedItems.map((match: ChildElement) => {
+			if (!(<any>match).innerEl.origContent) {
+				return;
+			}
+			// @ts-ignore
+			match.innerEl.setText((<any>match).innerEl.origContent);
+			delete (<any>match).innerEl.origContent;
+			// @ts-ignore
+			match.innerEl.removeClass("has-matches");
+		});
 
-    this.filtered = false;
-  };
+		this.filtered = false;
+	};
 
-  registerEventHandlers() {
-    this.registerEvent(
-      this.app.workspace.on("file-explorer-draggable-change", (value) => {
-        this.toggleFileExplorerSorters(value);
-      })
-    );
-    this.registerEvent(
-      this.app.workspace.on(
-        "file-explorer-sort-change",
-        (sortMethod: string) => {
-          this.settings.sortOrder = sortMethod;
-          this.saveSettings();
-          if (sortMethod === "custom") {
-            setTimeout(() => {
-              this.setFileExplorerSorter();
-            }, 10);
-          } else {
-            this.cleanupFileExplorerSorters();
-          }
-        }
-      )
-    );
-    this.registerEvent(
-      this.app.workspace.on(
-        "file-explorer-load",
-        (fileExplorer: FileExplorerView) => {
-          setTimeout(() => {
-            this.setFileExplorerSorter(fileExplorer);
-          }, 1000);
-        }
-      )
-    );
-    this.registerEvent(
-      this.app.workspace.on(
-        "bartender-leaf-split",
-        (_originLeaf: WorkspaceItem, newLeaf: WorkspaceItem) => {
-          const element: HTMLElement = newLeaf.tabsInnerEl as HTMLElement;
-          if (newLeaf.type === "tabs" && newLeaf instanceof WorkspaceTabs) {
-            if (requireApiVersion && !requireApiVersion("0.15.3")) {
-              this.setTabBarSorter(element, newLeaf);
-            }
-          }
-        }
-      )
-    );
+	registerEventHandlers() {
+		this.registerEvent(
+			this.app.workspace.on("file-explorer-draggable-change", (value) => {
+				this.toggleFileExplorerSorters(value);
+			})
+		);
+		this.registerEvent(
+			this.app.workspace.on("file-explorer-sort-change", (sortMethod: string) => {
+				this.settings.sortOrder = sortMethod;
+				this.saveSettings();
+				if (sortMethod === "custom") {
+					setTimeout(() => {
+						this.setFileExplorerSorter();
+					}, 10);
+				} else {
+					this.cleanupFileExplorerSorters();
+				}
+			})
+		);
+		this.registerEvent(
+			this.app.workspace.on("file-explorer-load", (fileExplorer: FileExplorerView) => {
+				setTimeout(() => {
+					this.setFileExplorerSorter(fileExplorer);
+				}, 1000);
+			})
+		);
+		this.registerEvent(
+			this.app.workspace.on(
+				"bartender-leaf-split",
+				(_originLeaf: WorkspaceItem, newLeaf: WorkspaceItem) => {
+					const element: HTMLElement = newLeaf.tabsInnerEl as HTMLElement;
+					if (newLeaf.type === "tabs" && newLeaf instanceof WorkspaceTabs) {
+						if (requireApiVersion && !requireApiVersion("0.15.3")) {
+							this.setTabBarSorter(element, newLeaf);
+						}
+					}
+				}
+			)
+		);
 
-    this.registerEvent(
-      this.app.workspace.on("ribbon-bar-updated", () => {
-        setTimeout(() => {
-          if (this.settings.ribbonBarOrder && this.ribbonBarSorter) {
-            this.setElementIDs(this.ribbonBarSorter.el, {
-              useClass: true,
-              useAria: true,
-              useIcon: true,
-            });
-            this.ribbonBarSorter.sort(this.settings.ribbonBarOrder);
-          }
-        }, 0);
-      })
-    );
-    this.registerEvent(
-      this.app.workspace.on("status-bar-updated", () => {
-        setTimeout(() => {
-          if (this.settings.statusBarOrder && this.statusBarSorter) {
-            this.setElementIDs(this.statusBarSorter.el, {
-              useClass: true,
-              useIcon: true,
-            });
-            this.statusBarSorter.sort(this.settings.statusBarOrder);
-          }
-        }, 0);
-      })
-    );
-  }
+		this.registerEvent(
+			this.app.workspace.on("ribbon-bar-updated", () => {
+				setTimeout(() => {
+					if (this.settings.ribbonBarOrder && this.ribbonBarSorter) {
+						this.setElementIDs(this.ribbonBarSorter.el, {
+							useClass: true,
+							useAria: true,
+							useIcon: true,
+						});
+						this.ribbonBarSorter.sort(this.settings.ribbonBarOrder);
+					}
+				}, 0);
+			})
+		);
+		this.registerEvent(
+			this.app.workspace.on("status-bar-updated", () => {
+				setTimeout(() => {
+					if (this.settings.statusBarOrder && this.statusBarSorter) {
+						this.setElementIDs(this.statusBarSorter.el, {
+							useClass: true,
+							useIcon: true,
+						});
+						this.statusBarSorter.sort(this.settings.statusBarOrder);
+					}
+				}, 0);
+			})
+		);
+	}
 
-  registerMonkeyPatches() {
-    const plugin = this;
-    this.register(
-      around(this.app.viewRegistry.constructor.prototype, {
-        registerView(old: any) {
-          return function (
-            type: string,
-            viewCreator: ViewCreator,
-            ...args: unknown[]
-          ) {
-            plugin.app.workspace.trigger("view-registered", type, viewCreator);
-            return old.call(this, type, viewCreator, ...args);
-          };
-        },
-      })
-    );
-    // This catches the initial FE view registration so that we can patch the sort button creation logic before
-    // the button is created
-    // TODO: Add conditional logic to patch the sort button even if we don't catch the initial startup
-    // 1) If layout ready, get the existing FE instance, create a patched button, and hide the existing button
-    // 2) Patch `addSortButton` to emit an event
-    // 3) On event,
-    if (this.app.workspace.layoutReady) {
-      const fileExplorer = this.getFileExplorer();
-      this.patchFileExplorer(fileExplorer);
-    } else {
-      const eventRef = this.app.workspace.on(
-        "view-registered",
-        (type: string, viewCreator: ViewCreator) => {
-          if (type !== "file-explorer") return;
-          this.app.workspace.offref(eventRef);
-          // @ts-ignore we need a leaf before any leafs exists in the workspace, so we create one from scratch
-          const leaf = new WorkspaceLeaf(plugin.app);
-          const fileExplorer = viewCreator(leaf) as FileExplorerView;
-          this.patchFileExplorer(fileExplorer);
-        }
-      );
-    }
-    this.register(
-      around(View.prototype, {
-        onunload(old: any) {
-          return function (...args) {
-            try {
-              if (this.iconSorter) {
-                this.iconSorter.destroy();
-                this.iconSorter = null;
-              }
-            } catch {}
-            return old.call(this, ...args);
-          };
-        },
-        onload(old: any) {
-          return function (...args) {
-            setTimeout(() => {
-              if (this.app.workspace.layoutReady) {
-                try {
-                  if (
-                    !(this.leaf.parentSplit instanceof WorkspaceTabs) &&
-                    this.hasOwnProperty("actionsEl") &&
-                    !this.iconSorter
-                  ) {
-                    this.iconSorter = plugin.setViewActionSorter(
-                      this.actionsEl,
-                      this
-                    );
-                  }
-                } catch {}
-              }
-            }, 200);
+	registerMonkeyPatches() {
+		const plugin = this;
+		this.register(
+			around(this.app.viewRegistry.constructor.prototype, {
+				registerView(old: any) {
+					return function (type: string, viewCreator: ViewCreator, ...args: unknown[]) {
+						plugin.app.workspace.trigger("view-registered", type, viewCreator);
+						return old.call(this, type, viewCreator, ...args);
+					};
+				},
+			})
+		);
+		// This catches the initial FE view registration so that we can patch the sort button creation logic before
+		// the button is created
+		// TODO: Add conditional logic to patch the sort button even if we don't catch the initial startup
+		// 1) If layout ready, get the existing FE instance, create a patched button, and hide the existing button
+		// 2) Patch `addSortButton` to emit an event
+		// 3) On event,
+		if (this.app.workspace.layoutReady) {
+			const fileExplorer = this.getFileExplorer();
+			this.patchFileExplorer(fileExplorer);
+		} else {
+			const eventRef = this.app.workspace.on(
+				"view-registered",
+				(type: string, viewCreator: ViewCreator) => {
+					if (type !== "file-explorer") return;
+					this.app.workspace.offref(eventRef);
+					// @ts-ignore we need a leaf before any leafs exists in the workspace, so we create one from scratch
+					const leaf = new WorkspaceLeaf(plugin.app);
+					const fileExplorer = viewCreator(leaf) as FileExplorerView;
+					this.patchFileExplorer(fileExplorer);
+				}
+			);
+		}
+		this.register(
+			around(View.prototype, {
+				onunload(old: any) {
+					return function (...args) {
+						try {
+							if (this.iconSorter) {
+								this.iconSorter.destroy();
+								this.iconSorter = null;
+							}
+						} catch {
+							//pass
+						}
+						return old.call(this, ...args);
+					};
+				},
+				onload(old: any) {
+					return function (...args) {
+						setTimeout(() => {
+							if (this.app.workspace.layoutReady) {
+								try {
+									if (
+										!(this.leaf.parentSplit instanceof WorkspaceTabs) &&
+										this.hasOwnProperty("actionsEl") &&
+										!this.iconSorter
+									) {
+										this.iconSorter = plugin.setViewActionSorter(this.actionsEl, this);
+									}
+								} catch {
+									//pass
+								}
+							}
+						}, 200);
 
-            return old.call(this, ...args);
-          };
-        },
-      })
-    );
-    if (Platform.isDesktop) {
-      this.register(
-        around(HTMLDivElement.prototype, {
-          addEventListener(old: any) {
-            return function (
-              type: string,
-              listener: EventListenerOrEventListenerObject,
-              options?: boolean | AddEventListenerOptions
-            ) {
-              if (
-                type === "mousedown" &&
-                listener instanceof Function &&
-                this.hasClass("workspace-tab-header")
-              ) {
-                const origListener = listener;
-                listener = (event) => {
-                  if (
-                    event instanceof MouseEvent &&
-                    (event?.altKey || event?.metaKey)
-                  )
-                    return;
-                  else origListener(event);
-                };
-              }
-              return old.call(this, type, listener, options);
-            };
-          },
-        })
-      );
-    }
-    this.register(
-      around(Workspace.prototype, {
-        splitLeaf(old: any) {
-          return function (
-            source: WorkspaceItem,
-            newLeaf: WorkspaceItem,
-            direction?: SplitDirection,
-            before?: boolean,
-            ...args
-          ) {
-            const result = old.call(
-              this,
-              source,
-              newLeaf,
-              direction,
-              before,
-              ...args
-            );
-            this.trigger("bartender-leaf-split", source, newLeaf);
-            return result;
-          };
-        },
-        changeLayout(old: any) {
-          return async function (workspace: any, ...args): Promise<void> {
-            const result = await old.call(this, workspace, ...args);
-            this.trigger("bartender-workspace-change");
-            return result;
-          };
-        },
-      })
-    );
-    this.register(
-      around(Plugin.prototype, {
-        addStatusBarItem(old: any) {
-          return function (...args): HTMLElement {
-            const result = old.call(this, ...args);
-            this.app.workspace.trigger("status-bar-updated");
-            return result;
-          };
-        },
-        addRibbonIcon(old: any) {
-          return function (...args): HTMLElement {
-            const result = old.call(this, ...args);
-            this.app.workspace.trigger("ribbon-bar-updated");
-            return result;
-          };
-        },
-      })
-    );
-  }
+						return old.call(this, ...args);
+					};
+				},
+			})
+		);
+		if (Platform.isDesktop) {
+			this.register(
+				around(HTMLDivElement.prototype, {
+					addEventListener(old: any) {
+						return function (
+							type: string,
+							listener: EventListenerOrEventListenerObject,
+							options?: boolean | AddEventListenerOptions
+						) {
+							if (
+								type === "mousedown" &&
+								listener instanceof Function &&
+								this.hasClass("workspace-tab-header")
+							) {
+								const origListener = listener;
+								listener = (event) => {
+									if (event instanceof MouseEvent && (event?.altKey || event?.metaKey))
+										return;
+									else origListener(event);
+								};
+							}
+							return old.call(this, type, listener, options);
+						};
+					},
+				})
+			);
+		}
+		this.register(
+			around(Workspace.prototype, {
+				splitLeaf(old: any) {
+					return function (
+						source: WorkspaceItem,
+						newLeaf: WorkspaceItem,
+						direction?: SplitDirection,
+						before?: boolean,
+						...args
+					) {
+						const result = old.call(this, source, newLeaf, direction, before, ...args);
+						this.trigger("bartender-leaf-split", source, newLeaf);
+						return result;
+					};
+				},
+				changeLayout(old: any) {
+					return async function (workspace: any, ...args): Promise<void> {
+						const result = await old.call(this, workspace, ...args);
+						this.trigger("bartender-workspace-change");
+						return result;
+					};
+				},
+			})
+		);
+		this.register(
+			around(Plugin.prototype, {
+				addStatusBarItem(old: any) {
+					return function (...args): HTMLElement {
+						const result = old.call(this, ...args);
+						this.app.workspace.trigger("status-bar-updated");
+						return result;
+					};
+				},
+				addRibbonIcon(old: any) {
+					return function (...args): HTMLElement {
+						const result = old.call(this, ...args);
+						this.app.workspace.trigger("ribbon-bar-updated");
+						return result;
+					};
+				},
+			})
+		);
+	}
 
-  patchFileExplorer(fileExplorer: FileExplorerView) {
-    const plugin = this;
-    const settings = this.settings;
-    if (!fileExplorer) {
-      return;
-    }
-    const InfinityScroll = fileExplorer.tree.infinityScroll.constructor;
-    // register clear first so that it gets called first onunload
-    this.register(() => this.clearFileExplorerFilter());
-    this.register(
-      around(InfinityScroll.prototype, {
-        compute(old: any) {
-          return function (...args: any[]) {
-            try {
-              if (this.scrollEl.hasClass("nav-files-container")) {
-                plugin.fileExplorerFilter.call(this, fileExplorer);
-              }
-            } catch (err) {
-              console.log(err);
-            }
-            const result = old.call(this, ...args);
-            return result;
-          };
-        },
-      })
-    );
-    this.register(
-      around(fileExplorer.headerDom.constructor.prototype, {
-        addSortButton(old: any) {
-          return function (...args: any[]) {
-            if (
-              this.navHeaderEl?.parentElement?.dataset?.type === "file-explorer"
-            ) {
-              plugin.setFileExplorerFilter(this);
-              return addSortButton.call(this, settings, ...args);
-            } else {
-              return old.call(this, ...args);
-            }
-          };
-        },
-      })
-    );
-  }
+	patchFileExplorer(fileExplorer: FileExplorerView) {
+		const plugin = this;
+		const settings = this.settings;
+		if (!fileExplorer) {
+			return;
+		}
+		const InfinityScroll = fileExplorer.tree.infinityScroll.constructor;
+		// register clear first so that it gets called first onunload
+		this.register(() => this.clearFileExplorerFilter());
+		this.register(
+			around(InfinityScroll.prototype, {
+				compute(old: any) {
+					return function (...args: any[]) {
+						try {
+							if (this.scrollEl.hasClass("nav-files-container")) {
+								plugin.fileExplorerFilter.call(this, fileExplorer);
+							}
+						} catch (err) {
+							console.log(err);
+						}
+						return old.call(this, ...args);
+					};
+				},
+			})
+		);
+		this.register(
+			around(fileExplorer.headerDom.constructor.prototype, {
+				addSortButton(old: any) {
+					return function (...args: any[]) {
+						if (this.navHeaderEl?.parentElement?.dataset?.type === "file-explorer") {
+							plugin.setFileExplorerFilter(this);
+							return addSortButton.call(this, settings, ...args);
+						} else {
+							return old.call(this, ...args);
+						}
+					};
+				},
+			})
+		);
+	}
 
-  insertSeparator(selector: string, className: string, rtl: Boolean) {
-    const elements = document.body.querySelectorAll(selector);
-    elements.forEach((el: HTMLElement) => {
-      const getSiblings = rtl ? getPreviousSiblings : getNextSiblings;
-      if (!el) {
-        return;
-      }
-      const separator = el.createDiv(`${className} separator`);
-      rtl && el.prepend(separator);
-      const glyphEl = separator.createDiv("glyph");
-      const glyphName = "plus-with-circle"; // this gets replaced using CSS
-      setIcon(glyphEl, glyphName);
-      separator.addClass("is-collapsed");
-      this.register(() => separator.detach());
-      let hideTimeout: NodeJS.Timeout;
-      separator.onClickEvent((event: MouseEvent) => {
-        if (separator.hasClass("is-collapsed")) {
-          Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-          separator.removeClass("is-collapsed");
-        } else {
-          getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
-          separator.addClass("is-collapsed");
-        }
-      });
-      el.onmouseenter = (ev) => {
-        if (hideTimeout) clearTimeout(hideTimeout);
-      };
-      el.onmouseleave = (ev) => {
-        if (this.settings.autoHide) {
-          hideTimeout = setTimeout(() => {
-            getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
-            separator.addClass("is-collapsed");
-          }, this.settings.autoHideDelay);
-        }
-      };
-      setTimeout(() => {
-        getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
-        separator.addClass("is-collapsed");
-      }, 0);
-    });
-  }
+	insertSeparator(selector: string, className: string, rtl: Boolean) {
+		const elements = document.body.querySelectorAll(selector);
+		elements.forEach((el: HTMLElement) => {
+			const getSiblings = rtl ? getPreviousSiblings : getNextSiblings;
+			if (!el) {
+				return;
+			}
+			const separator = el.createDiv(`${className} separator`);
+			rtl && el.prepend(separator);
+			const glyphEl = separator.createDiv("glyph");
+			const glyphName = "plus-with-circle"; // this gets replaced using CSS
+			setIcon(glyphEl, glyphName);
+			separator.addClass("is-collapsed");
+			this.register(() => separator.detach());
+			let hideTimeout: NodeJS.Timeout;
+			separator.onClickEvent((event: MouseEvent) => {
+				if (separator.hasClass("is-collapsed")) {
+					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+					separator.removeClass("is-collapsed");
+				} else {
+					getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
+					separator.addClass("is-collapsed");
+				}
+			});
+			el.onmouseenter = (ev) => {
+				if (hideTimeout) clearTimeout(hideTimeout);
+			};
+			el.onmouseleave = (ev) => {
+				if (this.settings.autoHide) {
+					hideTimeout = setTimeout(() => {
+						getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
+						separator.addClass("is-collapsed");
+					}, this.settings.autoHideDelay);
+				}
+			};
+			setTimeout(() => {
+				getSiblings(separator).forEach((el) => el.addClass("is-hidden"));
+				separator.addClass("is-collapsed");
+			}, 0);
+		});
+	}
 
-  setElementIDs(parentEl: HTMLElement, options: GenerateIdOptions) {
-    Array.from(parentEl.children).forEach((child) => {
-      if (child instanceof HTMLElement && !child.getAttribute("data-id")) {
-        child.setAttribute("data-id", generateId(child, options));
-      }
-    });
-  }
+	setElementIDs(parentEl: HTMLElement, options: GenerateIdOptions) {
+		Array.from(parentEl.children).forEach((child) => {
+			if (child instanceof HTMLElement && !child.getAttribute("data-id")) {
+				child.setAttribute("data-id", generateId(child, options));
+			}
+		});
+	}
 
-  setTabBarSorter(element: HTMLElement, leaf: WorkspaceTabs) {
-    this.setElementIDs(element, { useClass: true, useIcon: true });
-    return Sortable.create(element, {
-      group: "leftTabBar",
-      dataIdAttr: "data-id",
-      chosenClass: "bt-sortable-chosen",
-      delay: Platform.isMobile ? 200 : this.settings.dragDelay,
-      dropBubble: false,
-      dragoverBubble: false,
-      animation: ANIMATION_DURATION,
-      onChoose: () => element.parentElement?.addClass("is-dragging"),
-      onUnchoose: () => element.parentElement?.removeClass("is-dragging"),
-      onStart: () => {
-        document.body.addClass("is-dragging");
-        element.querySelector(".separator")?.removeClass("is-collapsed");
-        Array.from(element.children).forEach((el) =>
-          el.removeClass("is-hidden")
-        );
-      },
-      onEnd: (event) => {
-        document.body.removeClass("is-dragging");
-        if (event.oldIndex !== undefined && event.newIndex !== undefined) {
-          reorderArray(leaf.children, event.oldIndex, event.newIndex);
-          leaf.currentTab = event.newIndex;
-          leaf.recomputeChildrenDimensions();
-        }
-        this.app.workspace.requestSaveLayout();
-      },
-    });
-  }
+	setTabBarSorter(element: HTMLElement, leaf: WorkspaceTabs) {
+		this.setElementIDs(element, { useClass: true, useIcon: true });
+		return Sortable.create(element, {
+			group: "leftTabBar",
+			dataIdAttr: "data-id",
+			chosenClass: "bt-sortable-chosen",
+			delay: Platform.isMobile ? 200 : this.settings.dragDelay,
+			dropBubble: false,
+			dragoverBubble: false,
+			animation: ANIMATION_DURATION,
+			onChoose: () => element.parentElement?.addClass("is-dragging"),
+			onUnchoose: () => element.parentElement?.removeClass("is-dragging"),
+			onStart: () => {
+				document.body.addClass("is-dragging");
+				element.querySelector(".separator")?.removeClass("is-collapsed");
+				Array.from(element.children).forEach((el) => el.removeClass("is-hidden"));
+			},
+			onEnd: (event) => {
+				document.body.removeClass("is-dragging");
+				if (event.oldIndex !== undefined && event.newIndex !== undefined) {
+					reorderArray(leaf.children, event.oldIndex, event.newIndex);
+					leaf.currentTab = event.newIndex;
+					leaf.recomputeChildrenDimensions();
+				}
+				this.app.workspace.requestSaveLayout();
+			},
+		});
+	}
 
-  setStatusBarSorter() {
-    const el = document.body.querySelector(
-      "body > div.app-container > div.status-bar"
-    ) as HTMLElement;
-    if (el) {
-      this.setElementIDs(el, { useClass: true, useAria: true, useIcon: true });
-      this.statusBarSorter = Sortable.create(el, {
-        group: "statusBar",
-        dataIdAttr: "data-id",
-        chosenClass: "bt-sortable-chosen",
-        delay: Platform.isMobile ? 200 : this.settings.dragDelay,
-        animation: ANIMATION_DURATION,
-        onChoose: () => {
-          Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-        },
-        onStart: () => {
-          el.querySelector(".separator")?.removeClass("is-collapsed");
-          Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-        },
-        store: {
-          get: (sortable) => {
-            return this.settings.statusBarOrder;
-          },
-          set: (s) => {
-            this.settings.statusBarOrder = s.toArray();
-            this.saveSettings();
-          },
-        },
-      });
-    }
-  }
+	setStatusBarSorter() {
+		const el = document.body.querySelector(
+			"body > div.app-container > div.status-bar"
+		) as HTMLElement;
+		if (el) {
+			this.setElementIDs(el, { useClass: true, useAria: true, useIcon: true });
+			this.statusBarSorter = Sortable.create(el, {
+				group: "statusBar",
+				dataIdAttr: "data-id",
+				chosenClass: "bt-sortable-chosen",
+				delay: Platform.isMobile ? 200 : this.settings.dragDelay,
+				animation: ANIMATION_DURATION,
+				onChoose: () => {
+					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+				},
+				onStart: () => {
+					el.querySelector(".separator")?.removeClass("is-collapsed");
+					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+				},
+				store: {
+					get: (sortable) => {
+						return this.settings.statusBarOrder;
+					},
+					set: (s) => {
+						this.settings.statusBarOrder = s.toArray();
+						this.saveSettings();
+					},
+				},
+			});
+		}
+	}
 
-  setViewActionSorter(el: HTMLElement, view: View): Sortable | undefined {
-    this.setElementIDs(el, { useClass: true, useIcon: true });
-    const hasSorter = Object.values(el).find((value) =>
-      value?.hasOwnProperty("nativeDraggable")
-    );
-    if (hasSorter) return undefined;
-    const viewType = view?.getViewType() || "unknown";
-    return new Sortable(el, {
-      group: "actionBar",
-      dataIdAttr: "data-id",
-      chosenClass: "bt-sortable-chosen",
-      delay: Platform.isMobile ? 200 : this.settings.dragDelay,
-      sort: true,
-      animation: ANIMATION_DURATION,
-      onStart: () => {
-        el.querySelector(".separator")?.removeClass("is-collapsed");
-        Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-      },
-      store: {
-        get: () => {
-          return this.settings.actionBarOrder[viewType];
-        },
-        set: (s) => {
-          this.settings.actionBarOrder[viewType] = s.toArray();
-          this.saveSettings();
-        },
-      },
-    });
-  }
+	setViewActionSorter(el: HTMLElement, view: View): Sortable | undefined {
+		this.setElementIDs(el, { useClass: true, useIcon: true });
+		const hasSorter = Object.values(el).find((value) =>
+			value?.hasOwnProperty("nativeDraggable")
+		);
+		if (hasSorter) return undefined;
+		const viewType = view?.getViewType() || "unknown";
+		return new Sortable(el, {
+			group: "actionBar",
+			dataIdAttr: "data-id",
+			chosenClass: "bt-sortable-chosen",
+			delay: Platform.isMobile ? 200 : this.settings.dragDelay,
+			sort: true,
+			animation: ANIMATION_DURATION,
+			onStart: () => {
+				el.querySelector(".separator")?.removeClass("is-collapsed");
+				Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+			},
+			store: {
+				get: () => {
+					return this.settings.actionBarOrder[viewType];
+				},
+				set: (s) => {
+					this.settings.actionBarOrder[viewType] = s.toArray();
+					this.saveSettings();
+				},
+			},
+		});
+	}
 
-  setRibbonBarSorter() {
-    const el = document.body.querySelector(
-      "body > div.app-container div.side-dock-actions"
-    ) as HTMLElement;
-    if (el) {
-      this.setElementIDs(el, { useClass: true, useAria: true, useIcon: true });
-      this.ribbonBarSorter = Sortable.create(el, {
-        group: "ribbonBar",
-        dataIdAttr: "data-id",
-        delay: Platform.isMobile ? 200 : this.settings.dragDelay,
-        chosenClass: "bt-sortable-chosen",
-        animation: ANIMATION_DURATION,
-        onChoose: () => {
-          Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-        },
-        onStart: () => {
-          el.querySelector(".separator")?.removeClass("is-collapsed");
-          Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
-        },
-        store: {
-          get: (sortable) => {
-            return this.settings.ribbonBarOrder;
-          },
-          set: (s) => {
-            this.settings.ribbonBarOrder = s.toArray();
-            this.saveSettings();
-          },
-        },
-      });
-    }
-  }
+	setRibbonBarSorter() {
+		const el = document.body.querySelector(
+			"body > div.app-container div.side-dock-actions"
+		) as HTMLElement;
+		if (el) {
+			this.setElementIDs(el, { useClass: true, useAria: true, useIcon: true });
+			this.ribbonBarSorter = Sortable.create(el, {
+				group: "ribbonBar",
+				dataIdAttr: "data-id",
+				delay: Platform.isMobile ? 200 : this.settings.dragDelay,
+				chosenClass: "bt-sortable-chosen",
+				animation: ANIMATION_DURATION,
+				onChoose: () => {
+					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+				},
+				onStart: () => {
+					el.querySelector(".separator")?.removeClass("is-collapsed");
+					Array.from(el.children).forEach((el) => el.removeClass("is-hidden"));
+				},
+				store: {
+					get: (sortable) => {
+						return this.settings.ribbonBarOrder;
+					},
+					set: (s) => {
+						this.settings.ribbonBarOrder = s.toArray();
+						this.saveSettings();
+					},
+				},
+			});
+		}
+	}
 
-  setFileExplorerFilter(headerDom: FileExplorerHeader) {
-    const fileExplorerNav = headerDom.navHeaderEl;
-    if (!fileExplorerNav) {
-      return;
-    }
-    const fileExplorerFilter = fileExplorerNav.createDiv(
-      "search-input-container"
-    );
-    fileExplorerNav.insertAdjacentElement("afterend", fileExplorerFilter);
-    const fileExplorerFilterInput = fileExplorerFilter.createEl("input");
-    fileExplorerFilterInput.placeholder = "Type to filter...";
-    fileExplorerFilterInput.type = "text";
-    fileExplorerFilter.hide();
-    const filterScope = new Scope(this.app.scope);
-    fileExplorerFilterInput.onfocus = () => {
-      this.app.keymap.pushScope(filterScope);
-    };
-    fileExplorerFilterInput.onblur = () => {
-      this.app.keymap.popScope(filterScope);
-    };
-    fileExplorerFilterInput.oninput = (ev: InputEvent) => {
-      const fileExplorer = this.getFileExplorer();
-      if (ev.target instanceof HTMLInputElement) {
-        if (ev.target.value.length) {
-          clearButtonEl.show();
-        } else {
-          clearButtonEl.hide();
-        }
-        fileExplorer.tree.infinityScroll.filter = ev.target.value;
-      }
-      fileExplorer.tree.infinityScroll.compute();
-    };
-    const clearButtonEl = fileExplorerFilter.createDiv(
-      "search-input-clear-button",
-      (el) => {
-        el.addEventListener("click", function () {
-          (fileExplorerFilterInput.value = ""), clearButtonEl.hide();
-          fileExplorerFilterInput.focus();
-          fileExplorerFilterInput.dispatchEvent(new Event("input"));
-        }),
-          el.hide();
-      }
-    );
-  }
+	setFileExplorerFilter(headerDom: FileExplorerHeader) {
+		const fileExplorerNav = headerDom.navHeaderEl;
+		if (!fileExplorerNav) {
+			return;
+		}
+		const fileExplorerFilter = fileExplorerNav.createDiv("search-input-container");
+		fileExplorerNav.insertAdjacentElement("afterend", fileExplorerFilter);
+		const fileExplorerFilterInput = fileExplorerFilter.createEl("input");
+		fileExplorerFilterInput.placeholder = "Type to filter...";
+		fileExplorerFilterInput.type = "text";
+		fileExplorerFilter.hide();
+		const filterScope = new Scope(this.app.scope);
+		fileExplorerFilterInput.onfocus = () => {
+			this.app.keymap.pushScope(filterScope);
+		};
+		fileExplorerFilterInput.onblur = () => {
+			this.app.keymap.popScope(filterScope);
+		};
+		fileExplorerFilterInput.oninput = (ev: InputEvent) => {
+			const fileExplorer = this.getFileExplorer();
+			if (ev.target instanceof HTMLInputElement) {
+				if (ev.target.value.length) {
+					clearButtonEl.show();
+				} else {
+					clearButtonEl.hide();
+				}
+				fileExplorer.tree.infinityScroll.filter = ev.target.value;
+			}
+			fileExplorer.tree.infinityScroll.compute();
+		};
+		const clearButtonEl = fileExplorerFilter.createDiv(
+			"search-input-clear-button",
+			(el) => {
+				el.addEventListener("click", () => {
+					(fileExplorerFilterInput.value = ""), clearButtonEl.hide();
+					fileExplorerFilterInput.focus();
+					fileExplorerFilterInput.dispatchEvent(new Event("input"));
+				}),
+					el.hide();
+			}
+		);
+	}
 
-  setFileExplorerSorter(fileExplorer?: FileExplorerView) {
-    // TODO: Register sorter on new folder creation
-    // TODO: Unregister sorter on folder deletion
-    if (!fileExplorer) fileExplorer = this.getFileExplorer();
-    if (
-      !fileExplorer ||
-      this.settings.sortOrder !== "custom" ||
-      fileExplorer.hasCustomSorter
-    )
-      return;
-    const roots = this.getRootFolders(fileExplorer);
-    if (!roots || !roots.length) return;
-    for (const root of roots) {
-      const el = root?.childrenEl;
-      if (!el) continue;
-      let draggedItems: HTMLElement[];
-      fileExplorer.hasCustomSorter = true;
-      const dragEnabled = document.body
-        .querySelector("div.nav-action-button.drag-to-rearrange")
-        ?.hasClass("is-active")
-        ? true
-        : false;
+	setFileExplorerSorter(fileExplorer?: FileExplorerView) {
+		// TODO: Register sorter on new folder creation
+		// TODO: Unregister sorter on folder deletion
+		if (!fileExplorer) fileExplorer = this.getFileExplorer();
+		if (
+			!fileExplorer ||
+			this.settings.sortOrder !== "custom" ||
+			fileExplorer.hasCustomSorter
+		)
+			return;
+		const roots = this.getRootFolders(fileExplorer);
+		if (!roots || !roots.length) return;
+		for (const root of roots) {
+			const el = root?.childrenEl;
+			if (!el) continue;
+			let draggedItems: HTMLElement[];
+			fileExplorer.hasCustomSorter = true;
+			const dragEnabled = document.body
+				.querySelector("div.nav-action-button.drag-to-rearrange")
+				?.hasClass("is-active")
+				? true
+				: false;
 			const path = root.file?.path ?? "";
 
-      root.sorter = Sortable.create(el!, {
-        group: `fileExplorer${path}`,
-        forceFallback: true,
-        multiDrag: true,
-        // @ts-ignore
-        multiDragKey: "alt",
-        // selectedClass: "is-selected",
-        chosenClass: "bt-sortable-chosen",
-        delay: 0,
-        disabled: !dragEnabled,
-        sort: dragEnabled, // init with dragging disabled. the nav bar button will toggle on/off
-        animation: ANIMATION_DURATION,
-        onStart: (evt) => {
-          draggedItems = evt.items.length ? evt.items : [evt.item];
-        },
-        onMove: (evt) => {
-          // TODO: Refactor this
-          // Responsible for updating the internal Obsidian array that contains the file item order
-          // Without this logic, reordering is ephemeral and will be undone by Obisidian's native processes
-          const supportsVirtualChildren = requireApiVersion?.("0.15.0");
-          let _children = supportsVirtualChildren
-            ? root.vChildren?._children
-            : root.children;
-          if (!_children || !draggedItems?.length) return;
-          let children = _children.map((child) => child.el);
-          const adjacentEl = evt.related;
-          const targetIndex = children.indexOf(adjacentEl);
-          const firstItem = draggedItems.first();
-          const firstItemIndex = children.indexOf(firstItem!);
-          const _draggedItems = draggedItems.slice();
-          if (firstItemIndex > targetIndex) _draggedItems.reverse();
-          for (const item of _draggedItems) {
-            const itemIndex = children.indexOf(item);
-            _children = reorderArray(_children, itemIndex, targetIndex);
-            children = reorderArray(children, itemIndex, targetIndex);
-          }
-          this.settings.fileExplorerOrder[path] = _children.map(
-            (child) => child.file.path
-          );
-          this.saveSettings();
-          // return !adjacentEl.hasClass("nav-folder");
-        },
-        onEnd: (_evt) => {
-          draggedItems = [];
-          document.querySelector("body>div.drag-ghost")?.detach();
-        },
-      });
-    }
-  }
+			root.sorter = Sortable.create(el!, {
+				group: `fileExplorer${path}`,
+				forceFallback: true,
+				multiDrag: true,
+				// @ts-ignore
+				multiDragKey: "alt",
+				// selectedClass: "is-selected",
+				chosenClass: "bt-sortable-chosen",
+				delay: 0,
+				disabled: !dragEnabled,
+				sort: dragEnabled, // init with dragging disabled. the nav bar button will toggle on/off
+				animation: ANIMATION_DURATION,
+				onStart: (evt) => {
+					draggedItems = evt.items.length ? evt.items : [evt.item];
+				},
+				onMove: (evt) => {
+					// TODO: Refactor this
+					// Responsible for updating the internal Obsidian array that contains the file item order
+					// Without this logic, reordering is ephemeral and will be undone by Obisidian's native processes
+					const supportsVirtualChildren = requireApiVersion?.("0.15.0");
+					let _children = supportsVirtualChildren
+						? root.vChildren?._children
+						: root.children;
+					if (!_children || !draggedItems?.length) return;
+					let children = _children.map((child) => child.el);
+					const adjacentEl = evt.related;
+					const targetIndex = children.indexOf(adjacentEl);
+					const firstItem = draggedItems.first();
+					const firstItemIndex = children.indexOf(firstItem!);
+					const _draggedItems = draggedItems.slice();
+					if (firstItemIndex > targetIndex) _draggedItems.reverse();
+					for (const item of _draggedItems) {
+						const itemIndex = children.indexOf(item);
+						_children = reorderArray(_children, itemIndex, targetIndex);
+						children = reorderArray(children, itemIndex, targetIndex);
+					}
+					this.settings.fileExplorerOrder[path] = _children.map(
+						(child) => child.file.path
+					);
+					this.saveSettings();
+					// return !adjacentEl.hasClass("nav-folder");
+				},
+				onEnd: (_evt) => {
+					draggedItems = [];
+					document.querySelector("body>div.drag-ghost")?.detach();
+				},
+			});
+		}
+	}
 
-  getFileExplorer() {
-    const fileExplorer: FileExplorerView | undefined = this.app.workspace
-      .getLeavesOfType("file-explorer")
-      ?.first()?.view as unknown as FileExplorerView;
-    return fileExplorer;
-  }
+	getFileExplorer() {
+		const fileExplorer: FileExplorerView | undefined = this.app.workspace
+			.getLeavesOfType("file-explorer")
+			?.first()?.view as unknown as FileExplorerView;
+		return fileExplorer;
+	}
 
-  getRootFolders(
-    fileExplorer?: FileExplorerView
-  ): [RootElements | ChildElement] | undefined {
-    if (!fileExplorer) fileExplorer = this.getFileExplorer();
-    if (!fileExplorer) return;
-    const root = fileExplorer.tree?.infinityScroll?.rootEl;
-    return root && this.traverseRoots(root);
-  }
+	getRootFolders(
+		fileExplorer?: FileExplorerView
+	): [RootElements | ChildElement] | undefined {
+		if (!fileExplorer) fileExplorer = this.getFileExplorer();
+		if (!fileExplorer) return;
+		const root = fileExplorer.tree?.infinityScroll?.rootEl;
+		return root && this.traverseRoots(root);
+	}
 
-  traverseRoots(
-    root: RootElements | ChildElement,
-    items?: [RootElements | ChildElement]
-  ) {
-    if (!items) items = [root];
-    const supportsVirtualChildren = requireApiVersion?.("0.15.0");
-    const _children = supportsVirtualChildren
-      ? root.vChildren?._children
-      : root.children;
-    for (const child of _children || []) {
-      if (child.children || child.vChildren?._children) {
-        items.push(child);
-      }
-      this.traverseRoots(child, items);
-    }
-    return items;
-  }
+	traverseRoots(
+		root: RootElements | ChildElement,
+		items?: [RootElements | ChildElement]
+	) {
+		if (!items) items = [root];
+		const supportsVirtualChildren = requireApiVersion?.("0.15.0");
+		const _children = supportsVirtualChildren ? root.vChildren?._children : root.children;
+		for (const child of _children || []) {
+			if (child.children || child.vChildren?._children) {
+				items.push(child);
+			}
+			this.traverseRoots(child, items);
+		}
+		return items;
+	}
 
-  toggleFileExplorerSorters(enable: boolean) {
-    const fileExplorer = this.getFileExplorer();
-    const roots = this.getRootFolders(fileExplorer);
-    if (roots?.length) {
-      for (const root of roots) {
-        if (root.sorter) {
-          root.sorter.option("sort", enable);
-          root.sorter.option("disabled", !enable);
-        }
-      }
-    }
-  }
+	toggleFileExplorerSorters(enable: boolean) {
+		const fileExplorer = this.getFileExplorer();
+		const roots = this.getRootFolders(fileExplorer);
+		if (roots?.length) {
+			for (const root of roots) {
+				if (root.sorter) {
+					root.sorter.option("sort", enable);
+					root.sorter.option("disabled", !enable);
+				}
+			}
+		}
+	}
 
-  cleanupFileExplorerSorters() {
-    const fileExplorer = this.getFileExplorer();
-    const roots = this.getRootFolders(fileExplorer);
-    if (roots?.length) {
-      for (const root of roots) {
-        if (root.sorter) {
-          root.sorter.destroy();
-          delete root.sorter;
-          Object.keys(root.childrenEl!).forEach(
-            (key) =>
-              key.startsWith("Sortable") && delete (root.childrenEl as any)[key]
-          );
-          // sortable.destroy removes all of the draggble attributes :( so we put them back
-          root
-            .childrenEl!.querySelectorAll("div.nav-file-title")
-            .forEach((el: HTMLDivElement) => (el.draggable = true));
-          root
-            .childrenEl!.querySelectorAll("div.nav-folder-title")
-            .forEach((el: HTMLDivElement) => (el.draggable = true));
-        }
-      }
-    }
-    delete fileExplorer.hasCustomSorter;
-    // unset "custom" file explorer sort
-    if (this.app.vault.getConfig("fileSortOrder") === "custom") {
-      fileExplorer.setSortOrder("alphabetical");
-    }
-  }
+	cleanupFileExplorerSorters() {
+		const fileExplorer = this.getFileExplorer();
+		const roots = this.getRootFolders(fileExplorer);
+		if (roots?.length) {
+			for (const root of roots) {
+				if (root.sorter) {
+					root.sorter.destroy();
+					delete root.sorter;
+					Object.keys(root.childrenEl!).forEach(
+						(key) => key.startsWith("Sortable") && delete (root.childrenEl as any)[key]
+					);
+					// sortable.destroy removes all of the draggble attributes :( so we put them back
+					root
+						.childrenEl!.querySelectorAll("div.nav-file-title")
+						.forEach((el: HTMLDivElement) => (el.draggable = true));
+					root
+						.childrenEl!.querySelectorAll("div.nav-folder-title")
+						.forEach((el: HTMLDivElement) => (el.draggable = true));
+				}
+			}
+		}
+		delete fileExplorer.hasCustomSorter;
+		// unset "custom" file explorer sort
+		if (this.app.vault.getConfig("fileSortOrder") === "custom") {
+			fileExplorer.setSortOrder("alphabetical");
+		}
+	}
 
-  onunload(): void {
-    this.statusBarSorter?.destroy();
-    this.ribbonBarSorter?.destroy();
-    this.app.workspace.iterateAllLeaves((leaf) => {
-      let sorterParent: View | WorkspaceTabs | WorkspaceLeaf | boolean;
-      if (
-        (sorterParent = leaf?.iconSorter ? leaf : false) ||
-        (sorterParent = leaf?.view?.iconSorter ? leaf.view : false) ||
-        (sorterParent =
-          leaf?.parentSplit instanceof WorkspaceTabs &&
-          leaf?.parentSplit?.iconSorter
-            ? leaf?.parentSplit
-            : false)
-      ) {
-        try {
-          sorterParent.iconSorter?.destroy();
-        } catch (err) {
-        } finally {
-          delete sorterParent.iconSorter;
-        }
-      }
-    });
+	onunload(): void {
+		this.statusBarSorter?.destroy();
+		this.ribbonBarSorter?.destroy();
+		this.app.workspace.iterateAllLeaves((leaf) => {
+			let sorterParent: View | WorkspaceTabs | WorkspaceLeaf | boolean;
+			if (
+				(sorterParent = leaf?.iconSorter ? leaf : false) ||
+				(sorterParent = leaf?.view?.iconSorter ? leaf.view : false) ||
+				(sorterParent =
+					leaf?.parentSplit instanceof WorkspaceTabs && leaf?.parentSplit?.iconSorter
+						? leaf?.parentSplit
+						: false)
+			) {
+				try {
+					sorterParent.iconSorter?.destroy();
+				} finally {
+					delete sorterParent.iconSorter;
+				}
+			}
+		});
 
-    // clean up file explorer sorters
-    this.cleanupFileExplorerSorters();
-  }
+		// clean up file explorer sorters
+		this.cleanupFileExplorerSorters();
+	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,8 +70,8 @@ export default class BartenderPlugin extends Plugin {
 
   patchFileExplorerFolder() {
     let plugin = this;
-    let leaf = this.app.workspace.getLeaf(true);
-    let fileExplorer = this.app.viewRegistry.viewByType["file-explorer"](leaf) as FileExplorerView;
+    let leaf = plugin.app.workspace.getLeaf(true);
+    let fileExplorer = plugin.app.viewRegistry.viewByType["file-explorer"](leaf) as FileExplorerView;
     // @ts-ignore
     let tmpFolder = new TFolder(Vault, "");
     let Folder = fileExplorer.createFolderDom(tmpFolder).constructor;
@@ -80,7 +80,7 @@ export default class BartenderPlugin extends Plugin {
         sort(old: any) {
           return function (...args: any[]) {
             let order = plugin.settings.fileExplorerOrder[this.file.path];
-            if (this.fileExplorer.sortOrder === "custom") {
+            if (plugin.settings.sortOrder === "custom") {
               return folderSort.call(this, order, ...args);
             } else {
               return old.call(this, ...args);
@@ -144,8 +144,8 @@ export default class BartenderPlugin extends Plugin {
       '.workspace-leaf-content[data-type="file-explorer"] .search-input-container > input'
     );
     fileExplorerFilterEl && (fileExplorerFilterEl.value = "");
-    fileExplorer.dom.infinityScroll.filter = "";
-    fileExplorer.dom.infinityScroll.compute();
+    fileExplorer.tree.infinityScroll.filter = "";
+    fileExplorer.tree.infinityScroll.compute();
   }
 
   fileExplorerFilter = function () {
@@ -207,6 +207,8 @@ export default class BartenderPlugin extends Plugin {
     );
     this.registerEvent(
       this.app.workspace.on("file-explorer-sort-change", (sortMethod: string) => {
+        this.settings.sortOrder = sortMethod
+        this.saveSettings();
         if (sortMethod === "custom") {
           setTimeout(() => {
             this.setFileExplorerSorter();
@@ -388,8 +390,9 @@ export default class BartenderPlugin extends Plugin {
 
   patchFileExplorer(fileExplorer: FileExplorerView) {
     let plugin = this;
+    let settings = this.settings
     if (fileExplorer) {
-      let InfinityScroll = fileExplorer.dom.infinityScroll.constructor;
+      let InfinityScroll = fileExplorer.tree.infinityScroll.constructor;
       // register clear first so that it gets called first onunload
       this.register(() => this.clearFileExplorerFilter());
       this.register(
@@ -415,7 +418,7 @@ export default class BartenderPlugin extends Plugin {
             return function (...args: any[]) {
               if (this.navHeaderEl?.parentElement?.dataset?.type === "file-explorer") {
                 plugin.setFileExplorerFilter(this);
-                return addSortButton.call(this, ...args);
+                return addSortButton.call(this,settings, ...args);
               } else {
                 return old.call(this, ...args);
               }
@@ -621,9 +624,9 @@ export default class BartenderPlugin extends Plugin {
           } else {
             clearButtonEl.hide();
           }
-          fileExplorer.dom.infinityScroll.filter = ev.target.value;
+          fileExplorer.tree.infinityScroll.filter = ev.target.value;
         }
-        fileExplorer.dom.infinityScroll.compute();
+        fileExplorer.tree.infinityScroll.compute();
       };
       let clearButtonEl = fileExplorerFilter.createDiv("search-input-clear-button", function (el) {
         el.addEventListener("click", function () {
@@ -640,7 +643,7 @@ export default class BartenderPlugin extends Plugin {
     // TODO: Register sorter on new folder creation
     // TODO: Unregister sorter on folder deletion
     if (!fileExplorer) fileExplorer = this.getFileExplorer();
-    if (!fileExplorer || fileExplorer.sortOrder !== "custom" || fileExplorer.hasCustomSorter) return;
+    if (!fileExplorer || this.settings.sortOrder !== "custom" || fileExplorer.hasCustomSorter) return;
     let roots = this.getRootFolders(fileExplorer);
     if (!roots || !roots.length) return;
     for (let root of roots) {
@@ -710,7 +713,7 @@ export default class BartenderPlugin extends Plugin {
   getRootFolders(fileExplorer?: FileExplorerView): [RootElements | ChildElement] | undefined {
     if (!fileExplorer) fileExplorer = this.getFileExplorer();
     if (!fileExplorer) return;
-    let root = fileExplorer.dom?.infinityScroll?.rootEl;
+    let root = fileExplorer.tree?.infinityScroll?.rootEl;
     let roots = root && this.traverseRoots(root);
     return roots;
   }
@@ -763,7 +766,6 @@ export default class BartenderPlugin extends Plugin {
       }
     }
     delete fileExplorer.hasCustomSorter;
-
     // unset "custom" file explorer sort
     if (this.app.vault.getConfig("fileSortOrder") === "custom") {
       fileExplorer.setSortOrder("alphabetical");

--- a/src/main.ts
+++ b/src/main.ts
@@ -149,8 +149,13 @@ export default class BartenderPlugin extends Plugin {
   }
 
   fileExplorerFilter = function () {
+
     const supportsVirtualChildren = requireApiVersion && requireApiVersion("0.15.0");
-    let fileExplorer = this?.rootEl?.fileExplorer;
+    let leaf = this?.rootEl?.view?.app.workspace.getLeaf(true);
+    let fileExplorer = this?.rootEl?.view?.app.viewRegistry.viewByType["file-explorer"](leaf) as FileExplorerView;
+
+    //let fileExplorer = this?.rootEl?.fileExplorer;
+
     if (!fileExplorer) return;
     const _children = supportsVirtualChildren ? this.rootEl?.vChildren._children : this.rootEl?.children;
     if (!_children) return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -148,11 +148,11 @@ export default class BartenderPlugin extends Plugin {
     fileExplorer.tree.infinityScroll.compute();
   }
 
-  fileExplorerFilter = function () {
+  fileExplorerFilter = function (fileExplorer:FileExplorerView) {
 
     const supportsVirtualChildren = requireApiVersion && requireApiVersion("0.15.0");
-    let leaf = this?.rootEl?.view?.app.workspace.getLeaf(true);
-    let fileExplorer = this?.rootEl?.view?.app.viewRegistry.viewByType["file-explorer"](leaf) as FileExplorerView;
+/*    let leaf = this?.rootEl?.view?.app.workspace.getLeaf(true);
+    let fileExplorer = this?.rootEl?.view?.app.viewRegistry.viewByType["file-explorer"](leaf) as FileExplorerView;*/
 
     //let fileExplorer = this?.rootEl?.fileExplorer;
 
@@ -406,7 +406,7 @@ export default class BartenderPlugin extends Plugin {
             return function (...args: any[]) {
               try {
                 if (this.scrollEl.hasClass("nav-files-container")) {
-                  plugin.fileExplorerFilter.call(this);
+                  plugin.fileExplorerFilter.call(this,fileExplorer);
                 }
               } catch (err) {
                 console.log(err)

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1,5 +1,5 @@
-import { App, PluginSettingTab, Setting } from "obsidian";
-import BartenderPlugin from "../main";
+import { type App, PluginSettingTab, Setting } from "obsidian";
+import type BartenderPlugin from "../main";
 
 export interface BartenderSettings {
   statusBarOrder: string[];
@@ -9,7 +9,8 @@ export interface BartenderSettings {
   autoHide: boolean;
   autoHideDelay: number;
   dragDelay: number;
-  sortOrder:string;
+  sortOrder: string;
+  useCollapse: boolean;
 }
 
 export const DEFAULT_SETTINGS: BartenderSettings = {
@@ -20,7 +21,8 @@ export const DEFAULT_SETTINGS: BartenderSettings = {
   autoHide: false,
   autoHideDelay: 2000,
   dragDelay: 200,
-    sortOrder: "alphabetical"
+  sortOrder: "alphabetical",
+  useCollapse: true,
 };
 
 export class SettingTab extends PluginSettingTab {
@@ -31,18 +33,30 @@ export class SettingTab extends PluginSettingTab {
     this.plugin = plugin;
   }
 
-  hide() {}
-
   display(): void {
     const { containerEl } = this;
 
     containerEl.empty();
 
     new Setting(containerEl)
+      .setName("Support collapse")
+      .setDesc("Add a button to collapse the ribbon and status bar items")
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.useCollapse).onChange((value) => {
+          this.plugin.settings.useCollapse = value;
+          this.plugin.saveSettings();
+          this.display();
+        })
+      );
+    if (this.plugin.settings.useCollapse) { 
+
+    new Setting(containerEl)
       .setName("Auto Collapse")
-      .setDesc("Automatically hide ribbon and status bar items once your mouse leaves the icon container")
-      .addToggle(toggle =>
-        toggle.setValue(this.plugin.settings.autoHide).onChange(value => {
+      .setDesc(
+        "Automatically hide ribbon and status bar items once your mouse leaves the icon container"
+      )
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.autoHide).onChange((value) => {
           this.plugin.settings.autoHide = value;
           this.plugin.saveSettings();
         })
@@ -50,25 +64,30 @@ export class SettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName("Auto Collapse Delay")
-      .setDesc("How long to wait before auto collapsing hidden icons on the ribbon and status bar")
-      .addText(textfield => {
+      .setDesc(
+        "How long to wait before auto collapsing hidden icons on the ribbon and status bar"
+      )
+      .addText((textfield) => {
         textfield.setPlaceholder(String(2000));
         textfield.inputEl.type = "number";
         textfield.setValue(String(this.plugin.settings.autoHideDelay));
-        textfield.onChange(async value => {
+        textfield.onChange(async (value) => {
           this.plugin.settings.autoHideDelay = Number(value);
           this.plugin.saveSettings();
         });
       });
+    }
 
     new Setting(containerEl)
       .setName("Drag Start Delay (ms)")
-      .setDesc("How long to wait before triggering the drag behavior after clicking. ⚠️ Requires an app restart.")
-      .addText(textfield => {
+      .setDesc(
+        "How long to wait before triggering the drag behavior after clicking. ⚠️ Requires an app restart."
+      )
+      .addText((textfield) => {
         textfield.setPlaceholder(String(200));
         textfield.inputEl.type = "number";
         textfield.setValue(String(this.plugin.settings.dragDelay));
-        textfield.onChange(async value => {
+        textfield.onChange(async (value) => {
           this.plugin.settings.dragDelay = Number(value);
           this.plugin.saveSettings();
         });

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1,4 +1,4 @@
-import { type App, PluginSettingTab, Setting } from "obsidian";
+import { App, PluginSettingTab, Setting } from "obsidian";
 import type BartenderPlugin from "../main";
 
 export interface BartenderSettings {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -9,6 +9,7 @@ export interface BartenderSettings {
   autoHide: boolean;
   autoHideDelay: number;
   dragDelay: number;
+  sortOrder:string;
 }
 
 export const DEFAULT_SETTINGS: BartenderSettings = {
@@ -19,6 +20,7 @@ export const DEFAULT_SETTINGS: BartenderSettings = {
   autoHide: false,
   autoHideDelay: 2000,
   dragDelay: 200,
+    sortOrder: "alphabetical"
 };
 
 export class SettingTab extends PluginSettingTab {

--- a/src/types/obsidian.d.ts
+++ b/src/types/obsidian.d.ts
@@ -5,7 +5,11 @@ declare module "obsidian" {
   export interface Workspace extends Events {
     on(name: "status-bar-updated", callback: () => any, ctx?: any): EventRef;
     on(name: "ribbon-bar-updated", callback: () => any, ctx?: any): EventRef;
-    on(name: "bartender-workspace-change", callback: () => any, ctx?: any): EventRef;
+    on(
+      name: "bartender-workspace-change",
+      callback: () => any,
+      ctx?: any
+    ): EventRef;
     on(
       name: "bartender-leaf-split",
       callback: (originLeaf: WorkspaceItem, newLeaf: WorkspaceItem) => any,
@@ -13,8 +17,8 @@ declare module "obsidian" {
     ): EventRef;
   }
   interface Vault {
-    getConfig(config: String): unknown;
-    setConfig(config: String, value: any): void;
+    getConfig(config: string): unknown;
+    setConfig(config: string, value: any): void;
   }
   interface View {
     actionsEl: HTMLElement;

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -14,12 +14,36 @@ declare module "sortablejs" {
 }
 declare module "obsidian" {
   export interface Workspace extends Events {
-    on(name: "view-registered", callback: (type: string, viewCreator: ViewCreator) => any, ctx?: any): EventRef;
-    on(name: "file-explorer-load", callback: (fileExplorer: FileExplorerView) => any, ctx?: any): EventRef;
-    on(name: "file-explorer-sort-change", callback: (sortMethod: string) => any, ctx?: any): EventRef;
-    on(name: "infinity-scroll-compute", callback: (infinityScroll: InfinityScroll) => any, ctx?: any): EventRef;
-    on(name: "file-explorer-draggable-change", callback: (dragEnabled: boolean) => any, ctx?: any): EventRef;
-    on(name: "file-explorer-filter-change", callback: (filterEnabled: boolean) => any, ctx?: any): EventRef;
+    on(
+      name: "view-registered",
+      callback: (type: string, viewCreator: ViewCreator) => any,
+      ctx?: any
+    ): EventRef;
+    on(
+      name: "file-explorer-load",
+      callback: (fileExplorer: FileExplorerView) => any,
+      ctx?: any
+    ): EventRef;
+    on(
+      name: "file-explorer-sort-change",
+      callback: (sortMethod: string) => any,
+      ctx?: any
+    ): EventRef;
+    on(
+      name: "infinity-scroll-compute",
+      callback: (infinityScroll: InfinityScroll) => any,
+      ctx?: any
+    ): EventRef;
+    on(
+      name: "file-explorer-draggable-change",
+      callback: (dragEnabled: boolean) => any,
+      ctx?: any
+    ): EventRef;
+    on(
+      name: "file-explorer-filter-change",
+      callback: (filterEnabled: boolean) => any,
+      ctx?: any
+    ): EventRef;
   }
   export interface PluginInstance {
     id: string;
@@ -50,10 +74,13 @@ declare module "obsidian" {
     sortOrder: string;
     hasCustomSorter?: boolean;
     dragEnabled: boolean;
-    setSortOrder(order: String): void;
+    setSortOrder(order: string): void;
   }
   interface FileExplorerHeader {
-    addSortButton(sorter: (sortType: string) => void, sortOrder: () => string): void;
+    addSortButton(
+      sorter: (sortType: string) => void,
+      sortOrder: () => string
+    ): void;
     navHeaderEl: HTMLElement;
   }
   interface FileExplorerFolder {}
@@ -71,7 +98,7 @@ declare module "obsidian" {
   export interface VirtualChildren {
     children: ChildElement[];
     _children: ChildElement[];
-    owner: ChildElement
+    owner: ChildElement;
   }
   export interface RootElements {
     childrenEl: HTMLElement;

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -44,6 +44,7 @@ declare module "obsidian" {
   }
   export interface FileExplorerView extends View {
     dom: FileExplorerViewDom;
+    tree: FileExplorerViewDom;
     createFolderDom(folder: TFolder): FileExplorerFolder;
     headerDom: FileExplorerHeader;
     sortOrder: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import Fuse from "fuse.js";
 import { ChildElement, requireApiVersion } from "obsidian";
 
 export function getPreviousSiblings(el: HTMLElement, filter?: (el: HTMLElement) => boolean): HTMLElement[] {
-  var sibs = [];
+  const sibs = [];
   while ((el = el.previousSibling as HTMLElement)) {
     if (el.nodeType === 3) continue; // text node
     if (!filter || filter(el)) sibs.push(el);
@@ -10,7 +10,7 @@ export function getPreviousSiblings(el: HTMLElement, filter?: (el: HTMLElement) 
   return sibs;
 }
 export function getNextSiblings(el: HTMLElement, filter?: (el: HTMLElement) => boolean): HTMLElement[] {
-  var sibs = [];
+  const sibs = [];
   while ((el = el.nextSibling as HTMLElement)) {
     if (el.nodeType === 3) continue; // text node
     if (!filter || filter(el)) sibs.push(el);
@@ -27,13 +27,13 @@ export interface GenerateIdOptions {
 }
 
 export function generateId(el: HTMLElement, options?: GenerateIdOptions) {
-  let classes = options?.useClass
+  const classes = options?.useClass
     ? Array.from(el.classList)
         .filter(c => !c.startsWith("is-"))
         .sort()
         .join(" ")
     : "";
-  let str =
+  const str =
     (options?.useTag ? el.tagName : "") +
     (options?.useClass ? classes : "") +
     (options?.useText ? el.textContent : "") +
@@ -105,7 +105,7 @@ export const getItems = (items: ChildElement[]): ChildElement[] => {
 
 type NestedObject = { [key: string]: string | NestedObject };
 
-export const highlight = (fuseSearchResult: any, highlightClassName: string = "suggestion-highlight") => {
+export const highlight = (fuseSearchResult: any, highlightClassName = "suggestion-highlight") => {
   const set = (obj: NestedObject, path: string, value: any) => {
     const pathValue = path.split(".");
     let i;
@@ -118,7 +118,7 @@ export const highlight = (fuseSearchResult: any, highlightClassName: string = "s
   };
 
   const generateHighlightedText = (inputText: string, regions: number[][] = []) => {
-    let result = regions
+    const result = regions
       .reduce((str, [start, end]) => {
         str[start] = `<span class="${highlightClassName}">${str[start]}`;
         str[end] = `${str[end]}</span>`;
@@ -152,7 +152,7 @@ export function removeExt(obj: any) {
 }
 
 export function getFn(obj: any, path: string[]) {
-  var value = Fuse.config.getFn(obj, path);
+  const value = Fuse.config.getFn(obj, path);
   if (Array.isArray(value)) {
     return value.map(el => removeExt(el));
   }

--- a/styles.css
+++ b/styles.css
@@ -60,7 +60,10 @@ div.separator svg {
 .hider-ribbon .side-dock-ribbon div.separator svg {
   -webkit-mask-image: var(--left-indicator);
 }
-.hider-ribbon .side-dock-ribbon div.separator.is-collapsed.bt-sortable-chosen svg {
+.hider-ribbon
+  .side-dock-ribbon
+  div.separator.is-collapsed.bt-sortable-chosen
+  svg {
   /* so that the icon updates to show the expand icon on drag start */
   -webkit-mask-image: var(--left-indicator);
 }
@@ -119,24 +122,31 @@ body.is-dragging .tooltip {
 .workspace-tab-header-container.is-dragging .workspace-tab-container-after {
   background: none;
 }
-.workspace-tab-header-container.is-dragging .workspace-tab-header-inner-icon:hover {
+.workspace-tab-header-container.is-dragging
+  .workspace-tab-header-inner-icon:hover {
   background: none;
 }
 
-.workspace-leaf-content[data-type="file-explorer"] .nav-header .search-input-container {
+.workspace-leaf-content[data-type="file-explorer"]
+  .nav-header
+  .search-input-container {
   display: none;
 }
 
-.workspace-leaf-content[data-type="file-explorer"] .nav-header .search-input-container.is-active {
+.workspace-leaf-content[data-type="file-explorer"]
+  .nav-header
+  .search-input-container.is-active {
   display: block;
 }
 
-div.nav-action-button[data-sort-method] + div.nav-action-button.drag-to-rearrange {
+div.nav-action-button[data-sort-method]
+  + div.nav-action-button.drag-to-rearrange {
   display: none;
 }
 
-div.nav-action-button[data-sort-method="custom"] + div.nav-action-button.drag-to-rearrange {
-  display: block;
+div.nav-action-button[data-sort-method="custom"]
+  + div.nav-action-button.drag-to-rearrange {
+  display: flex;
 }
 
 .nav-files-container .sortable-fallback {


### PR DESCRIPTION
I used the fork of @zansbang to start my version. They PR is from #56 and start supports for Obsidian 1.5.8.

What's was fixed:
- Root was not able to be sorted: Internally, I choosen to update `getSortedFolderItems` instead of `sort`. This allows to sort directly from the root instead of each folder. Note that roots are registered under "" (empty) in the settings (`data.json`).
- Fixed some css issues in the file explorer head. Now, the icon should be aligned!

What's was added:
- Support for moved/deleted files: Now, the settings should be updated when a file is edited (moved/renamed) or deleted.
- Add an option to disable the collapse in status-bar and ribbon: I think the last Obsidian update handle the ribbon perfectly and this option bored me.
- Update icons in the head of the explorer to use the Obsidian last's icon and also change the icon when using custom sort.

Dep:
- Updated to last Obsidian API version
- Added https://github.com/Fevol/obsidian-typings to get more typings for obsidian and prevent error 

If you want to use my version, I released the [update](https://github.com/Mara-Li/obsidian-bartender/releases/tag/0.5.12).